### PR TITLE
Initial check-in of codeformatter scripts

### DIFF
--- a/Tools/RunCodeFormatter.ps1
+++ b/Tools/RunCodeFormatter.ps1
@@ -2,6 +2,12 @@
 # The easiest way to use this is to add it as a content file to your
 # Visual Studio project, and whenever you want to run codeformatter
 # just right click and select "Execute as Script"
+#
+# The tool will be installed to %LOCALAPPDATA%\CodeFormatter-XXX,
+# suffixed by the release ID. If this script finds that the tool is
+# present, the existing version will be used. This means that if
+# the release ID changes, the latest version of codeformatter will
+# be downloaded on the next run.
 
 # Update from time-to-time by looking at:
 # https://github.com/dotnet/codeformatter/releases


### PR DESCRIPTION
Add two scripts. The first one installs the codeformatter tool to the local machine (into the APPDATA folder). The second runs the tool over the solution.

Both could use some clean up. For example, I'm not sure the copyright header is 100% correct, it might need to mention the code license.
