### PR TITLE
Update website prefix

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Google Cloud Powershell Cmdlet Reference
-baseurl: "/gcloud-powershell"
+baseurl: "/google-cloud-powershell"
 url: "http://googlecloudplatform.github.io"
 
 # Enable cust plug-ins.


### PR DESCRIPTION
Renaming the repo broke the website. This one-line change fixes it.

The new website version has already been pushed. See issue #112 .
