### PR TITLE
Add Set-GcsObject cmdlet

### DIFF
--- a/Google.PowerShell.IntegrationTests/Storage/Storage.GcsBucketWebsite.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Storage/Storage.GcsBucketWebsite.Tests.ps1
@@ -19,7 +19,7 @@ Describe "{Delete, Write}-GcsBucketWebsite" {
         $result.Website.MainPageSuffix | Should BeExactly "www.google.com"
         $result.Website.NotFoundPage | Should BeExactly "www.google.com/404"
 
-        # Confirm added
+        # Confirm added.
         $result = Get-GcsBucket $bucketName
         $result.Website.MainPageSuffix | Should BeExactly "www.google.com"
         $result.Website.NotFoundPage | Should BeExactly "www.google.com/404"

--- a/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
@@ -193,6 +193,35 @@ Describe "Get-GcsObject" {
     }
 }
 
+Describe "Set-GcsObject" {
+
+    $bucket = "gcps-get-object-testing"
+    Create-TestBucket $project $bucket
+    Add-TestFile $bucket "testfile1.txt"
+
+    It "should work" {
+        # Default ACLs set on the object from the bucket.
+        $obj = Get-GcsObject $bucket "testfile1.txt"
+        $obj.Acl.Count | Should Be 4
+        $obj.Acl[0].ID.Contains("/project-owners-") | Should Be $true
+        $obj.Acl[1].ID.Contains("/project-editors-") | Should Be $true
+        $obj.Acl[2].ID.Contains("/project-viewers-") | Should Be $true
+        $obj.Acl[3].ID.Contains("/user-") | Should Be $true
+
+        # Set new value for ACLs using a predefined set.
+        $obj = $obj | Set-GcsObject -PredefinedAcl PublicRead
+        $obj.Acl.Count | Should Be 2
+        $obj.Acl[0].ID.Contains("/user-") | Should Be $true
+        $obj.Acl[1].ID.Contains("/allUsers") | Should Be $true
+
+        # Confirm the change took place.
+        $obj = Get-GcsObject $bucket "testfile1.txt"
+        $obj.Acl.Count | Should Be 2
+        $obj.Acl[0].ID.Contains("/user-") | Should Be $true
+        $obj.Acl[1].ID.Contains("/allUsers") | Should Be $true
+    }
+}
+
 Describe "Find-GcsObject" {
 
     $bucket = "gcps-get-object-testing"

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -64,6 +64,7 @@ namespace Google.PowerShell.CloudStorage
             ObjectsResource.InsertMediaUpload insertReq = service.Objects.Insert(
                 newGcsObject, bucket, contentStream, contentType);
             insertReq.PredefinedAcl = predefinedAcl;
+            insertReq.Projection = ProjectionEnum.Full;
 
             var finalProgress = insertReq.Upload();
             if (finalProgress.Exception != null)
@@ -152,11 +153,8 @@ namespace Google.PowerShell.CloudStorage
         /// OWNER access, and allUsers get READER access.
         /// </para>
         /// </summary>
-        [ValidateSet(
-            "authenticatedRead", "bucketOwnerFullControl", "bucketOwnerRead",
-            "private", "projectPrivate", "publicRead", IgnoreCase = false)]
         [Parameter(Mandatory = false)]
-        public string PredefinedAcl { get; set; }
+        public PredefinedAclEnum? PredefinedAcl { get; set; }
 
         /// <summary>
         /// <para type="description">
@@ -165,28 +163,6 @@ namespace Google.PowerShell.CloudStorage
         /// </summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter Force { get; set; }
-
-        protected PredefinedAclEnum? GetPredefinedAcl()
-        {
-            switch (PredefinedAcl)
-            {
-                case "authenticatedRead": return PredefinedAclEnum.AuthenticatedRead;
-                case "bucketOwnerFullControl": return PredefinedAclEnum.BucketOwnerFullControl;
-                case "bucketOwnerRead": return PredefinedAclEnum.BucketOwnerRead;
-                case "private": return PredefinedAclEnum.Private__;
-                case "projectPrivate": return PredefinedAclEnum.ProjectPrivate;
-                case "publicRead": return PredefinedAclEnum.PublicRead;
-
-                case "":
-                case null:
-                    return null;
-                default:
-                    throw new PSInvalidOperationException(
-                        string.Format("Invalid predefined ACL: {0}", PredefinedAcl));
-            }
-
-            return null;
-        }
 
         protected override void ProcessRecord()
         {
@@ -228,7 +204,7 @@ namespace Google.PowerShell.CloudStorage
 
                 Object newGcsObject = UploadGcsObject(
                     service, Bucket, ObjectName, contentStream,
-                    objContentType, GetPredefinedAcl());
+                    objContentType, PredefinedAcl);
 
                 WriteObject(newGcsObject);
             }
@@ -304,7 +280,98 @@ namespace Google.PowerShell.CloudStorage
             var service = GetStorageService();
 
             ObjectsResource.GetRequest getReq = service.Objects.Get(Bucket, ObjectName);
+            getReq.Projection = ObjectsResource.GetRequest.ProjectionEnum.Full;
             Object gcsObject = getReq.Execute();
+            WriteObject(gcsObject);
+        }
+    }
+
+    /// <summary>
+    /// <para type="synopsis">
+    /// Set-GcsObject updates metadata associated with a Cloud Storage Object.
+    /// </para>
+    /// <para type="description">
+    /// Updates the metadata associated with a Cloud Storage Object, such as ACLs.
+    /// </para>
+    /// </summary>
+    [Cmdlet(VerbsCommon.Set, "GcsObject")]
+    public class SetGcsObjectCmdlet : GcsCmdlet
+    {
+        private class ParameterSetNames
+        {
+            public const string FromBucketAndObjName = "FromBucketAndObjName";
+            public const string FromObject = "FromObjectObject";
+        }
+
+        /// <summary>
+        /// <para type="description">
+        /// Name of the bucket to check. Will also accept a Bucket object.
+        /// </para>
+        /// </summary>
+        [Parameter(Position = 0, Mandatory = true, ParameterSetName = ParameterSetNames.FromBucketAndObjName)]
+        [PropertyByTypeTransformationAttribute(Property = "Name", TypeToTransform = typeof(Bucket))]
+        public string Bucket { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// Name of the object to update.
+        /// </para>
+        /// </summary>
+        [Parameter(Position = 1, Mandatory = true, ParameterSetName = ParameterSetNames.FromBucketAndObjName)]
+        public string ObjectName { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// Storage object instance to update.
+        /// </para>
+        /// </summary>
+        [Parameter(Position = 0, Mandatory = true,
+            ValueFromPipeline = true, ParameterSetName = ParameterSetNames.FromObject)]
+        public Object Object { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// Provide a predefined ACL to the object. e.g. "publicRead" where the project owner gets
+        /// OWNER access, and allUsers get READER access.
+        /// </para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public ObjectsResource.UpdateRequest.PredefinedAclEnum? PredefinedAcl { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            base.ProcessRecord();
+            var service = GetStorageService();
+
+            string bucket = null;
+            string objectName = null;
+            switch (ParameterSetName)
+            {
+                case ParameterSetNames.FromBucketAndObjName:
+                    bucket = Bucket;
+                    objectName = ObjectName;
+                    break;
+                case ParameterSetNames.FromObject:
+                    bucket = Object.Bucket;
+                    objectName = Object.Name;
+                    break;
+                default:
+                    throw UnknownParameterSetException;
+            }
+
+            // You cannot specify both an ACL list and a predefined ACL using the API. (b/30358979?)
+            // We issue a GET + Update. Since we aren't using ETags, there is a potential for a
+            // race condition.
+            var getReq = service.Objects.Get(bucket, objectName);
+            getReq.Projection = ObjectsResource.GetRequest.ProjectionEnum.Full;
+            Object objectInsert = getReq.Execute();
+            // The API doesn't allow both predefinedAcl and access controls. So drop existing ACLs.
+            objectInsert.Acl = null;
+
+            ObjectsResource.UpdateRequest updateReq = service.Objects.Update(objectInsert, bucket, objectName);
+            updateReq.PredefinedAcl = PredefinedAcl;
+
+            Object gcsObject = updateReq.Execute();
             WriteObject(gcsObject);
         }
     }
@@ -651,6 +718,7 @@ namespace Google.PowerShell.CloudStorage
                 try
                 {
                     ObjectsResource.GetRequest getReq = service.Objects.Get(Bucket, ObjectName);
+                    getReq.Projection = ObjectsResource.GetRequest.ProjectionEnum.Full;
                     Object existingGcsObject = getReq.Execute();
                     contentType = existingGcsObject.ContentType;
                 }
@@ -715,6 +783,7 @@ namespace Google.PowerShell.CloudStorage
             try
             {
                 ObjectsResource.GetRequest objGetReq = service.Objects.Get(Bucket, ObjectName);
+                objGetReq.Projection = ObjectsResource.GetRequest.ProjectionEnum.Full;
                 objGetReq.Execute();
 
                 WriteObject(true);


### PR DESCRIPTION
This PR adds a new `Set-GcsObject` cmdlet that allows you to update the metadata of an object. Currently the only operation is that it will allow you to specify a default ACL (e.g. "publicRead".)

In addition the PR changes the project for a few API calls, previously we had the default behavior where the API would return the object without the ACL information. This leads to confusion since it looks like objects have no ACLs at all, when in reality they do.

I'll log some issues (assigned to me) to continue fleshing out ACL-support in GCS. Specifically some integration tests for default object ACLs on buckets, and that they work correctly. Also, the ability to read/write object metadata as key/value pairs.