### PR TITLE
Make Read-GcsObject take an input object from the pipeline.

### DIFF
--- a/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
@@ -301,6 +301,20 @@ Describe "Read-GcsObject" {
         Remove-Item $tempFileName
     }
 
+    It "should take pipeline input" {
+        # GetTempFileName creates a 0-byte file, which will cause problems
+        # because the cmdlet won't overwrite it without -Force.
+        $tempFileName = [System.IO.Path]::Combine(
+                 [System.IO.Path]::GetTempPath(),
+                 [System.IO.Path]::GetRandomFileName())
+        Get-GcsObject $bucket $testObjectName |
+            Read-GcsObject -OutFile $tempFileName
+
+        Get-Content $tempFileName | Should BeExactly $testFileContents
+
+        Remove-Item $tempFileName
+    }
+
     It "won't overwrite existing files" {
         # Creates a 0-byte file, which we won't clobber.
         $tempFileName = [System.IO.Path]::GetTempFileName()
@@ -384,11 +398,6 @@ Describe "Write-GcsObject" {
         Remove-Item $tempFile
     }
 
-    It "requires the -File or -Contents parameter be named (or from pipeline)" {
-        { Write-GcsObject "bucket-name" "object-name" "contents-or-file?" } `
-            | Should Throw "Parameter set cannot be resolved using the specified named parameters"
-    }
-
     It "will accept contents from the pipeline" {
         # Note that we aren't specifying the -Contents or -File parameter. Instead
         # that is set by the pipeline.
@@ -432,7 +441,18 @@ Describe "Write-GcsObject" {
         Pop-Location
     }
 
-    # TODO(chrsmith): Confirm it works for 0-byte files (currently it doesn't).
+    It "should write zero bytes" {
+        $objectName = "write-zero-bytes-test"
+
+        # Create the original GCS object.
+        "contents" | New-GcsObject $bucket $objectName
+
+        Write-GcsObject $bucket $objectName
+        $emptyObj = Get-GcsObject $bucket $objectName
+        $emptyObj.Size | Should Be 0
+        Remove-GcsObject $emptyObj
+    }
+
     # TODO(chrsmith): Confirm Write-GcsObject doesn't remove object metadata, such
     # as its existing ACLs. (Since we are uploading a new object in-place.)
 }

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -411,7 +411,7 @@ namespace Google.PowerShell.CloudStorage
         /// </para>
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ParameterSetName = ParameterSetNames.FromName)]
-        [PropertyByTypeTransformationAttribute(Property = "Name", TypeToTransform = typeof(Bucket))]
+        [PropertyByTypeTransformation(Property = "Name", TypeToTransform = typeof(Bucket))]
         public string Bucket { get; set; }
 
         /// <summary>
@@ -476,13 +476,18 @@ namespace Google.PowerShell.CloudStorage
     [Cmdlet(VerbsCommunications.Read, "GcsObject")]
     public class ReadGcsObjectCmdlet : GcsObjectCmdlet
     {
+        private class ParameterSetNames
+        {
+            public const string ByName = "ByName";
+            public const string ByObject = "ByObject";
+        }
         /// <summary>
         /// <para type="description">
         /// Name of the bucket containing the object. Will also accept a Bucket object.
         /// </para>
         /// </summary>
-        [Parameter(Position = 0, Mandatory = true)]
-        [PropertyByTypeTransformationAttribute(Property = "Name", TypeToTransform = typeof(Bucket))]
+        [Parameter(Position = 0, Mandatory = true, ParameterSetName = ParameterSetNames.ByName)]
+        [PropertyByTypeTransformation(Property = "Name", TypeToTransform = typeof(Bucket))]
         public string Bucket { get; set; }
 
         /// <summary>
@@ -490,15 +495,24 @@ namespace Google.PowerShell.CloudStorage
         /// Name of the object to read.
         /// </para>
         /// </summary>
-        [Parameter(Position = 1, Mandatory = true)]
+        [Parameter(Position = 1, Mandatory = true, ParameterSetName = ParameterSetNames.ByName)]
         public string ObjectName { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// The Google Cloud Storage bucket object to read.
+        /// </para>
+        /// </summary>
+        [Parameter(ParameterSetName = ParameterSetNames.ByObject, Mandatory = true, ValueFromPipeline = true)]
+        public Object InputObject { get; set; }
 
         /// <summary>
         /// <para type="description">
         /// Local file path to write the contents to.
         /// </para>
         /// </summary>
-        [Parameter(Position = 2, Mandatory = false)]
+        [Parameter(ParameterSetName = ParameterSetNames.ByName, Position = 2)]
+        [Parameter(ParameterSetName = ParameterSetNames.ByObject)]
         public string OutFile { get; set; }
 
         // Consider adding a -PassThru parameter to enable writing the contents to the
@@ -517,6 +531,12 @@ namespace Google.PowerShell.CloudStorage
         {
             base.ProcessRecord();
             var service = GetStorageService();
+
+            if (InputObject != null)
+            {
+                Bucket = InputObject.Bucket;
+                ObjectName = InputObject.Name;
+            }
 
             string uri = GetBaseUri(Bucket, ObjectName);
             var downloader = new MediaDownloader(service);
@@ -578,13 +598,19 @@ namespace Google.PowerShell.CloudStorage
     [Cmdlet(VerbsCommunications.Write, "GcsObject")]
     public class WriteGcsObjectCmdlet : GcsObjectCmdlet
     {
+        private class ParameterSetNames
+        {
+            public const string FromString = "FromString";
+            public const string FromFile = "FromFile";
+        }
+
         /// <summary>
         /// <para type="description">
         /// Name of the bucket containing the object. Will also accept a Bucket object.
         /// </para>
         /// </summary>
         [Parameter(Position = 0, Mandatory = true)]
-        [PropertyByTypeTransformationAttribute(Property = "Name", TypeToTransform = typeof(Bucket))]
+        [PropertyByTypeTransformation(Property = "Name", TypeToTransform = typeof(Bucket))]
         public string Bucket { get; set; }
 
         /// <summary>
@@ -600,7 +626,8 @@ namespace Google.PowerShell.CloudStorage
         /// Text content to write to the Storage object. Ignored if File is specified.
         /// </para>
         /// </summary>
-        [Parameter(Position = 2, Mandatory = false, ValueFromPipeline = true, ParameterSetName = "ContentsFromString")]
+        [Parameter(ParameterSetName = ParameterSetNames.FromString,
+            Position = 2, ValueFromPipeline = true)]
         public string Contents { get; set; }
 
         /// <summary>
@@ -608,7 +635,7 @@ namespace Google.PowerShell.CloudStorage
         /// Local file path to read, writing its contents into Cloud Storage.
         /// </para>
         /// </summary>
-        [Parameter(Position = 2, Mandatory = false, ParameterSetName = "ContentsFromFile")]
+        [Parameter(Mandatory = true, ParameterSetName = ParameterSetNames.FromFile)]
         public string File { get; set; }
 
         /// <summary>
@@ -624,7 +651,7 @@ namespace Google.PowerShell.CloudStorage
             base.ProcessRecord();
             var service = GetStorageService();
 
-            Stream contentStream = null;
+            Stream contentStream;
             if (!string.IsNullOrEmpty(File))
             {
                 string qualifiedPath = GetFullPath(File);
@@ -639,7 +666,7 @@ namespace Google.PowerShell.CloudStorage
                 // Get the underlying byte representation of the string using the same encoding (UTF-16).
                 // So the data will be written in the same format it is passed, rather than converting to
                 // UTF-8 or UTF-32 when writen to Cloud Storage.
-                byte[] contentBuffer = Encoding.Unicode.GetBytes(Contents);
+                byte[] contentBuffer = Encoding.Unicode.GetBytes(Contents ?? "");
                 contentStream = new MemoryStream(contentBuffer);
             }
 

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -500,7 +500,7 @@ namespace Google.PowerShell.CloudStorage
 
         /// <summary>
         /// <para type="description">
-        /// The Google Cloud Storage bucket object to read.
+        /// The Google Cloud Storage object to read.
         /// </para>
         /// </summary>
         [Parameter(ParameterSetName = ParameterSetNames.ByObject, Mandatory = true, ValueFromPipeline = true)]


### PR DESCRIPTION
Folded into this is a fix for making Write-GcsObject write zero bytes correctly. This fixes issue #127.