### PR TITLE
Make SettingsVersion parameter mandatory in Failover-GcSqlInstance cmdlet

### DIFF
--- a/Google.PowerShell.IntegrationTests/SQL/SQL.GcSqlInstances.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/SQL/SQL.GcSqlInstances.Tests.ps1
@@ -611,11 +611,12 @@ Describe "Failover-GcSqlInstance" {
     Occasionally, there have also been "Unknown Errors."
     They are thus commented out as per Jim's advice. 
 
-    It "should failover a test instance" {
-        Failover-GcSqlInstance $instance
+    It "should failover a test instance with a correct settings version specified" {
+        $currentSettingsVersion = (Get-GcSqlInstance -Name $instance).Settings.SettingsVersion
+        Failover-GcSqlInstance $instance $currentSettingsVersion
 
         $operations = Get-GcSqlOperation -Instance $instance | where { $_.OperationType -eq "FAILOVER" }
-        $operations.Count | Should Be ($numFailoverOps + 1)
+        $operations.Count | Should Be ($numFailoverOps + 4)
         $operations[0].Status | Should Match "DONE"
         $operations[0].Error | Should Match ""
     }
@@ -627,7 +628,7 @@ Describe "Failover-GcSqlInstance" {
         $operations.Count | Should Be ($numFailoverOps + 2)
         $operations[0].Status | Should Match "DONE"
         $operations[0].Error | Should Match ""
-     }
+    }
     
     It "should failover a pipelined instance (instance and default projects differ)" {
         $nonDefaultProject = "asdf"
@@ -645,24 +646,14 @@ Describe "Failover-GcSqlInstance" {
 
         # Reset gcloud config back to default project (gcloud-powershell-testing)
         gcloud config set project $defaultProject
-     }
-
-    It "should failover a test instance with a correct settings version specified" {
-        $currentSettingsVersion = (Get-GcSqlInstance -Name $instance).Settings.SettingsVersion
-        Failover-GcSqlInstance $instance -SettingsVersion $currentSettingsVersion
-
-        $operations = Get-GcSqlOperation -Instance $instance | where { $_.OperationType -eq "FAILOVER" }
-        $operations.Count | Should Be ($numFailoverOps + 4)
-        $operations[0].Status | Should Match "DONE"
-        $operations[0].Error | Should Match ""
     }
     #>
 
     It "should fail to failover a test instance with an incorrect settings version specified" {
         $wrongSettingsVersion = (Get-GcSqlInstance -Name $instance).Settings.SettingsVersion + 50
 
-        { Failover-GcSqlInstance $instance -SettingsVersion $wrongSettingsVersion } | Should Throw "412"
-        { Failover-GcSqlInstance $instance -SettingsVersion $wrongSettingsVersion } | Should Throw "Input or retrieved settings version does not match current settings version for this instance."
+        { Failover-GcSqlInstance $instance $wrongSettingsVersion } | Should Throw "412"
+        { Failover-GcSqlInstance $instance $wrongSettingsVersion } | Should Throw "Input or retrieved settings version does not match current settings version for this instance."
     }
 }
 

--- a/Google.PowerShell.IntegrationTests/SQL/SQL.GcSqlInstances.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/SQL/SQL.GcSqlInstances.Tests.ps1
@@ -616,7 +616,7 @@ Describe "Failover-GcSqlInstance" {
         Failover-GcSqlInstance $instance $currentSettingsVersion
 
         $operations = Get-GcSqlOperation -Instance $instance | where { $_.OperationType -eq "FAILOVER" }
-        $operations.Count | Should Be ($numFailoverOps + 4)
+        $operations.Count | Should Be ($numFailoverOps + 1)
         $operations[0].Status | Should Match "DONE"
         $operations[0].Error | Should Match ""
     }

--- a/Google.PowerShell/Sql/GcSqlInstanceCmdlets.cs
+++ b/Google.PowerShell/Sql/GcSqlInstanceCmdlets.cs
@@ -1456,12 +1456,10 @@ namespace Google.PowerShell.Sql
 
         /// <summary>
         /// <para type="description">
-        /// The current settings version of the Instance. If not specified, it will be retrieved from the settings data
-        /// of the Instance. 
+        /// The current settings version of the Instance.
         /// </para>
         /// </summary>
-        [Parameter(Mandatory = false)]
-        [ValidateNotNullOrEmpty]
+        [Parameter(ParameterSetName = ParameterSetNames.ByName, Mandatory = true, Position = 1)]
         public long? SettingsVersion { get; set; }
 
         protected override void ProcessRecord()
@@ -1480,6 +1478,7 @@ namespace Google.PowerShell.Sql
                 case ParameterSetNames.ByInstance:
                     projectName = InstanceObject.Project;
                     instanceName = InstanceObject.Name;
+                    SettingsVersion = InstanceObject.Settings.SettingsVersion;
                     instanceObject = InstanceObject; 
                     break;
                 default:
@@ -1490,7 +1489,7 @@ namespace Google.PowerShell.Sql
             {
                 FailoverContext = new FailoverContext
                 {
-                    SettingsVersion = SettingsVersion ?? instanceObject.Settings.SettingsVersion
+                    SettingsVersion = SettingsVersion
                 }
             };
 


### PR DESCRIPTION
Make SettingsVersion parameter mandatory in Failover-GcSqlInstance cmdlet. For consistency with API and other cmdlets. 