### PR TITLE
Add OutputType whitelist for Cmdlet Doc Checker

### DIFF
--- a/Tools/CheckCmdletXmlDocs.psm1
+++ b/Tools/CheckCmdletXmlDocs.psm1
@@ -152,7 +152,7 @@ function Check-CmdletDoc() {
 # Get the cmdlets explicitly named as a subset of all Google Cloud cmdlets.
 function GetCmdletsByName ($cmdletNames, $allCmdlets) {
     PrintElementsNotFound $cmdletNames $allCmdlets.Name "`nThe following cmdlets you named were not found:"
-    return @($allCmdlets | where { $cmdletNames -contains $_.Name })
+    return @($allCmdlets | where Name -in $cmdletNames)
 }
 
 # Get the names of the cmdlets in the OuputType whitelist.

--- a/gcloud-powershell.sln
+++ b/gcloud-powershell.sln
@@ -21,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{31BC29EB
 	ProjectSection(SolutionItems) = preProject
 		Tools\CheckCmdletXmlDocs.psm1 = Tools\CheckCmdletXmlDocs.psm1
 		Tools\GenerateWebsiteData.ps1 = Tools\GenerateWebsiteData.ps1
+		Tools\OutputTypeWhitelist.txt = Tools\OutputTypeWhitelist.txt
 		Tools\RunCodeFormatter.ps1 = Tools\RunCodeFormatter.ps1
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Have the Cmdlet Doc Checker take in a whitelist for cmdlets that don't have/need an OutputType attribute (e.g., cmdlets that don't output any objects). Also, 	change order of helper functions in Cmdlet Doc checker to more logically follow the order the functions are called.