### PR TITLE
CheckCmdletXmlDocs: Ensure parameters have descriptions, fix 1 spacing, 1 missing return. 

### DIFF
--- a/Tools/CheckCmdletXmlDocs.psm1
+++ b/Tools/CheckCmdletXmlDocs.psm1
@@ -141,6 +141,9 @@ function Check-CmdletDoc() {
             $wroteWarnings = ((DoDeepExampleCheck $docObj) -or $wroteWarnings)
         }
 
+        # Check that all parameters have a valid (non-null, non-whitespace) description. 
+        $wroteWarnings = ((WriteParameterDescriptionWarnings $docObj) -or $wroteWarnings)
+
         if (-not ($wroteWarnings)) {
             Write-Host "PASSED" -ForegroundColor "Green" -BackgroundColor "Black"
         }
@@ -282,6 +285,20 @@ function DoDeepExampleCheck($docObj) {
 
         if ($noOutput.Count -gt 0) {
             "Example number(s) " + ($noOutput -join ", ") + " has(have) no outputs." | Write-Warning
+            $wroteWarnings = $true
+        }
+    }
+
+    return $wroteWarnings
+}
+
+# Check that all parameters for the cmdlet have a valid (non-null, non-whitespace) description. 
+function WriteParameterDescriptionWarnings ($docObj) {
+    $wroteWarnings = $false
+
+    foreach ($parameter in $docObj.parameters.parameter) {
+        if ([String]::IsNullOrWhiteSpace($parameter.description.Text)) {
+            "Parameter `"" + $parameter.name + "`" does not have a valid description." | Write-Warning
             $wroteWarnings = $true
         }
     }

--- a/Tools/CheckCmdletXmlDocs.psm1
+++ b/Tools/CheckCmdletXmlDocs.psm1
@@ -162,8 +162,8 @@ function GetOutputTypeWhitelist ($outputWhitelistDirectory, $allCmdlets) {
         return $null
     } 
     $outputWhitelist = $outputWhitelist.Split(" *`n+", [System.StringSplitOptions]::RemoveEmptyEntries)
-    PrintElementsNotFound $outputWhitelist $allCmdlets.Name "`nThe following cmdlets from the OutputType whitelist were not found: "
-    $outputWhitelist = @($allCmdlets.Name | where { $outputWhitelist -contains $_ })
+    PrintElementsNotFound $outputWhitelist $allCmdlets.Name "`nThe following cmdlets from the OutputType whitelist were not found:"
+    return @($allCmdlets.Name | where { $outputWhitelist -contains $_ })
 }
 
 # Print a list of the elements in sublist that are not part of list. 


### PR DESCRIPTION
Add check in CheckCmdletXmlDocs to ensure that all parameters have a valid (non-null, non-whitespace) description. Fix spacing and add deleted return statement as well. 