### PR TITLE
Add positional parameter testing to DNS Pester tests and bring CmdletChecker up to date

### DIFF
--- a/Google.PowerShell.IntegrationTests/Dns/Dns.GcdChange.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Dns/Dns.GcdChange.Tests.ps1
@@ -29,7 +29,7 @@ Describe "Get-GcdChange" {
     Add-GcdChange -Project $project -Zone $testZone1 -Remove $testRrsetA
 
     It "should work and retrieve 3 changes (including A-type record addition & deletion)" {
-        $changes = Get-GcdChange -Project $project -Zone $testZone1
+        $changes = Get-GcdChange -Project $project $testZone1
 
         $changes.Count | Should Be 3
 
@@ -48,7 +48,7 @@ Describe "Get-GcdChange" {
     }
 
     It "should work and retrieve the first change from creation by Id" {
-        $changes = Get-GcdChange -Project $project -Zone $testZone1 -ChangeId "0"
+        $changes = Get-GcdChange -Project $project $testZone1 "0"
         $changes.Count | Should Be 1
         $changes.GetType().FullName | Should Match $changeType
         $changes.Id | Should Be 0
@@ -84,27 +84,27 @@ Describe "Add-GcdChange" {
     $copyChange.Deletions = $null
 
     It "should fail to add a Change to a non-existent project" {
-        { Add-GcdChange -Project $nonExistProject -Zone $testZone1 -ChangeRequest $copyChange } | Should Throw "400"
+        { Add-GcdChange -Project $nonExistProject $testZone1 $copyChange } | Should Throw "400"
     }
 
     It "should give access errors as appropriate" {
         # Don't know who created the "asdf" project.
-        { Add-GcdChange -Project $accessErrProject -Zone $testZone1 -ChangeRequest $copyChange } | Should Throw "403"
+        { Add-GcdChange -Project $accessErrProject $testZone1 $copyChange } | Should Throw "403"
     }
 
     It "should fail to add a Change to a non-existent ManagedZone of an existing project" {
-        { Add-GcdChange -Project $project -Zone $nonExistManagedZone -ChangeRequest $copyChange } | Should Throw "404"
+        { Add-GcdChange -Project $project $nonExistManagedZone $copyChange } | Should Throw "404"
     }
 
     It "should fail to add a Change with only null/empty values for Add/Remove" {
-        { Add-GcdChange -Project $project -Zone $testZone1 -Add $null -Remove $null } | Should Throw $Err_NeedChangeContent
-        { Add-GcdChange -Project $project -Zone $testZone1 -Add $null -Remove @() } | Should Throw $Err_NeedChangeContent
-        { Add-GcdChange -Project $project -Zone $testZone1 -Add @() -Remove @() } | Should Throw $Err_NeedChangeContent
+        { Add-GcdChange -Project $project $testZone1 -Add $null -Remove $null } | Should Throw $Err_NeedChangeContent
+        { Add-GcdChange -Project $project $testZone1 -Add $null -Remove @() } | Should Throw $Err_NeedChangeContent
+        { Add-GcdChange -Project $project $testZone1 -Add @() -Remove @() } | Should Throw $Err_NeedChangeContent
     }
 
     It "should work and add 1 Change from Change Request (CNAME-type record addition)" {
         $initChanges = Get-GcdChange -Project $project -Zone $testZone1
-        $newChange = Add-GcdChange -Project $project -Zone $testZone1 -ChangeRequest $copyChange
+        $newChange = Add-GcdChange -Project $project $testZone1 $copyChange
         $allChanges = Get-GcdChange -Project $project -Zone $testZone1
 
         Compare-Object $newChange $allChanges[0] -Property Additions,Deletions,Id,Kind,StartTime | Should Match $null
@@ -130,7 +130,7 @@ Describe "Add-GcdChange" {
     It "should support Add/Remove arguments in same call" {
         $initChanges = Get-GcdChange -Project $project -Zone $testZone1
         
-        $newChange = Add-GcdChange -Project $project -Zone $testZone1 -Add $addRrset1,$addRrset2 -Remove $rmRrset1,$rmRrset2
+        $newChange = Add-GcdChange -Project $project $testZone1 -Add $addRrset1,$addRrset2 -Remove $rmRrset1,$rmRrset2
         $allChanges = Get-GcdChange -Project $project -Zone $testZone1
 
         Compare-Object $newChange $allChanges[0] -Property Additions,Deletions,Id,Kind,StartTime | Should Match $null
@@ -152,6 +152,6 @@ Describe "Add-GcdChange" {
     Add-GcdChange -Project $project -Zone $testZone2 -Remove $copyChange.Additions
 
     It "should fail to add Change that tries to remove a non-existent ResourceRecord" {
-        { Add-GcdChange -Project $project -Zone $testZone1 -Remove $rmRrset1 } | Should Throw "404"
+        { Add-GcdChange -Project $project $testZone1 -Remove $rmRrset1 } | Should Throw "404"
     }
 }

--- a/Google.PowerShell.IntegrationTests/Dns/Dns.GcdManagedZone.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Dns/Dns.GcdManagedZone.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Get-GcdManagedZone" {
     }
 
     It "should fail to return non-existent ManagedZones of existing project" {
-        { Get-GcdManagedZone -Project $project -ManagedZone $nonExistManagedZone } | Should Throw "404"
+        { Get-GcdManagedZone -Project $project $nonExistManagedZone } | Should Throw "404"
     }
 
     It "should list exactly 0 ManagedZones in project" {
@@ -42,7 +42,7 @@ Describe "Get-GcdManagedZone" {
     }
 
     It "should work and retrieve ManagedZone testZone2" {
-        $zones = Get-GcdManagedZone -Project $project -ManagedZone $testZone2
+        $zones = Get-GcdManagedZone -Project $project $testZone2
         $zones.GetType().FullName | Should Match $managedZoneType
         $zones.Description | Should Match $testDescrip2
         $zones.DnsName | Should Match $dnsName2
@@ -60,16 +60,16 @@ Describe "Add-GcdManagedZone" {
     }
 
     It "should fail to create a ManagedZone in a non-existent project" {
-        { Add-GcdManagedZone -Project $nonExistProject -Name $testZone1 -DnsName $dnsName1 } | Should Throw "400"
+        { Add-GcdManagedZone -Project $nonExistProject $testZone1 $dnsName1 } | Should Throw "400"
     }
 
     It "should give access errors as appropriate" {
         # Don't know who created the "asdf" project.
-        { Add-GcdManagedZone -Project $accessErrProject -Name $testZone1 -DnsName $dnsName1 } | Should Throw "403"
+        { Add-GcdManagedZone -Project $accessErrProject $testZone1 $dnsName1 } | Should Throw "403"
     }
 
     It "should create and return 1 zone" {
-        $newZone = Add-GcdManagedZone -Project $project -Name $testZone1 -DnsName $dnsName1
+        $newZone = Add-GcdManagedZone -Project $project $testZone1 $dnsName1
         $newZone.GetType().FullName | Should Match $managedZoneType
         $newZone.Description | Should Match ""
         $newZone.DnsName | Should Match $dnsName1
@@ -78,12 +78,12 @@ Describe "Add-GcdManagedZone" {
     }
 
     It "should fail to create a new ManagedZone with the same name as an existing one" {
-        { Add-GcdManagedZone -Project $project -Name $testZone1 -DnsName $dnsName1 } | Should Throw "409"
+        { Add-GcdManagedZone -Project $project $testZone1 $dnsName1 } | Should Throw "409"
     }
 
     It "should work and have Get-GcdManagedZone retrieve the correct details of both created zones" {
         # Create second zone for testing with dns name that lacks ending period (should be auto-added by cmdlet)
-        Add-GcdManagedZone -Project $project -Name $testZone2 -DnsName $dnsName2 -Description $testDescrip2
+        Add-GcdManagedZone -Project $project $testZone2 $dnsName2 $testDescrip2
 
         (Get-GcdManagedZone -Project $project).Count | Should Be 2
 
@@ -112,16 +112,16 @@ Describe "Remove-GcdManagedZone" {
     }
 
     It "should fail to delete a ManagedZone in a non-existent project" {
-        { Remove-GcdManagedZone -Project $nonExistProject -ManagedZone $testZone1 } | Should Throw "400"
+        { Remove-GcdManagedZone -Project $nonExistProject $testZone1 } | Should Throw "400"
     }
 
     It "should give access errors as appropriate" {
         # Don't know who created the "asdf" project.
-        { Remove-GcdManagedZone -Project $accessErrProject -ManagedZone $testZone1 } | Should Throw "403"
+        { Remove-GcdManagedZone -Project $accessErrProject $testZone1 } | Should Throw "403"
     }
 
     It "should fail to delete a non-existent ManagedZone in an existent project" {
-        { Remove-GcdManagedZone -Project $project -ManagedZone $nonExistManagedZone } | Should Throw "404"
+        { Remove-GcdManagedZone -Project $project $nonExistManagedZone } | Should Throw "404"
     }
 
     # Create two zones for testing 
@@ -129,7 +129,7 @@ Describe "Remove-GcdManagedZone" {
     Add-GcdManagedZone -Project $project -Name $testZone2 -DnsName $dnsName2
 
     It "should delete only the first zone created and output nothing" {
-        Remove-GcdManagedZone -Project $project -ManagedZone $testZone1 | Should Be $null
+        Remove-GcdManagedZone -Project $project $testZone1 | Should Be $null
 
         { Get-GcdManagedZone -Project $project -ManagedZone $testZone1 } | Should Throw "404"
         (Get-GcdManagedZone -Project $project).Count | Should Be 1
@@ -151,7 +151,7 @@ Describe "Remove-GcdManagedZone" {
     Add-GcdChange -Project $project -Zone $testZone1 -Add $testRrsetA,$testRrsetCNAME
 
     It "should delete a non-empty zone when -Force is specified" {
-        Remove-GcdManagedZone -Project $project -ManagedZone $testZone1 -Force | Should Be $null
+        Remove-GcdManagedZone -Project $project $testZone1 -Force | Should Be $null
 
         { Get-GcdManagedZone -Project $project -ManagedZone $testZone1 } | Should Throw "404"
         (Get-GcdManagedZone -Project $project).Count | Should Be 1

--- a/Google.PowerShell.IntegrationTests/Dns/Dns.GcdQuota.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Dns/Dns.GcdQuota.Tests.ps1
@@ -11,8 +11,21 @@ Describe "Get-GcdQuota" {
         { Get-GcdQuota -Project $accessErrProject } | Should Throw "403"
     }
 
-    It "should work and retrieve valid DNS quota information" {
+    It "should work and retrieve valid DNS quota information for a named project" {
         $quotaInfo = Get-GcdQuota -Project $project
+
+        $quotaInfo.GetType().FullName | Should Match $quotaType
+
+        $quotaInfo.ManagedZones -ge 50 | Should Be $true
+        $quotaInfo.ResourceRecordsPerRrset -ge 50 | Should Be $true
+        $quotaInfo.RrsetAdditionsPerChange -ge 50 | Should Be $true
+        $quotaInfo.RrsetDeletionsPerChange -ge 50 | Should Be $true
+        $quotaInfo.RrsetsPerManagedZone -ge 9000 | Should Be $true
+        $quotaInfo.TotalRrdataSizePerChange -ge 9000 | Should Be $true
+    }
+
+    It "should work and retrieve valid DNS quota information for the current config's project" {
+        $quotaInfo = Get-GcdQuota
 
         $quotaInfo.GetType().FullName | Should Match $quotaType
 

--- a/Google.PowerShell.IntegrationTests/Dns/Dns.GcdResourceRecordSet.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Dns/Dns.GcdResourceRecordSet.Tests.ps1
@@ -9,16 +9,16 @@ Describe "Get-GcdResourceRecordSet" {
     }
 
     It "should fail to return ResourceRecordSets of non-existent project" {
-        { Get-GcdResourceRecordSet -Project $nonExistProject -Zone $testZone1 } | Should Throw "400"
+        { Get-GcdResourceRecordSet -Project $nonExistProject $testZone1 } | Should Throw "400"
     }
 
     It "should give access errors as appropriate" {
         # Don't know who created the "asdf" project.
-        { Get-GcdResourceRecordSet -Project $accessErrProject -Zone $testZone1 } | Should Throw "403"
+        { Get-GcdResourceRecordSet -Project $accessErrProject $testZone1 } | Should Throw "403"
     }
 
     It "should fail to return ResourceRecordSets of non-existent ManagedZone of existing project" {
-        { Get-GcdResourceRecordSet -Project $project -Zone $nonExistManagedZone } | Should Throw "404"
+        { Get-GcdResourceRecordSet -Project $project $nonExistManagedZone } | Should Throw "404"
     }
 
     # Create zone for testing 
@@ -28,7 +28,7 @@ Describe "Get-GcdResourceRecordSet" {
     Add-GcdChange -Project $project -Zone $testZone1 -Add $testRrsetA,$testRrsetAAAA
 
     It "should work and retrieve 4 ResourceRecordSets (2 from creation, 2 added)" {
-        $rrsets = Get-GcdResourceRecordSet -Project $project -Zone $testZone1
+        $rrsets = Get-GcdResourceRecordSet -Project $project $testZone1
         $rrsets.Count | Should Be 4
 
         # The object type, Kind, and Name should be the same for all ResourceRecordSets
@@ -45,7 +45,7 @@ Describe "Get-GcdResourceRecordSet" {
     }
 
     It "should work and retrieve only the NS and AAAA type records" {
-        $rrsets = Get-GcdResourceRecordSet -Project $project -Zone $testZone1 -Filter "NS","AAAA"
+        $rrsets = Get-GcdResourceRecordSet -Project $project $testZone1 "NS","AAAA"
         $rrsets.Count | Should Be 2
 
         ($rrsets | Get-Member).TypeName | Should Match $rrsetType
@@ -62,11 +62,11 @@ Describe "Get-GcdResourceRecordSet" {
 Describe "New-GcdResourceRecordSet" {
     
     It "should fail to create a new ResourceRecordSet with an invalid record type" {
-        { New-GcdResourceRecordSet -Name $dnsName1 -Rrdata $rrdataA1 -Type "Invalid" } | Should Throw "ValidateSet"
+        { New-GcdResourceRecordSet $dnsName1 $rrdataA1 "Invalid" } | Should Throw "ValidateSet"
     }
 
     It "should work and create a new ResourceRecordSet with the specified properties and default ttl (A type record)" {
-        $rrset = New-GcdResourceRecordSet -Name $dnsName1 -Rrdata $rrdataA1,$rrdataA2 -Type "A"
+        $rrset = New-GcdResourceRecordSet $dnsName1 $rrdataA1,$rrdataA2 "A"
         $rrset.Count | Should Be 1
 
         $rrset.GetType().FullName | Should Match $rrsetType
@@ -80,7 +80,7 @@ Describe "New-GcdResourceRecordSet" {
     }
 
     It "should work and create a new ResourceRecordSet with the specified properties and custom ttl (AAAA type record)" {
-        $rrset = New-GcdResourceRecordSet -Name $dnsName1_1 -Rrdata $rrdataAAAA -Type "AAAA" -Ttl $ttl1
+        $rrset = New-GcdResourceRecordSet $dnsName1_1 $rrdataAAAA "AAAA" $ttl1
         $rrset.Count | Should Be 1
 
         $rrset.GetType().FullName | Should Match $rrsetType
@@ -92,8 +92,8 @@ Describe "New-GcdResourceRecordSet" {
     }
 
     It "should work and create ResourceRecordSets of other types (CNAME and TXT)" {
-        $rrsetCNAME = New-GcdResourceRecordSet -Name $dnsName1_2 -Rrdata $rrdataCNAME1_2 -Type "CNAME" -Ttl $ttl1
-        $rrsetTXT = New-GcdResourceRecordSet -Name $dnsName1 -Rrdata $rrdataTXT1 -Type "TXT" -Ttl $ttl1
+        $rrsetCNAME = New-GcdResourceRecordSet $dnsName1_2 $rrdataCNAME1_2 "CNAME" $ttl1
+        $rrsetTXT = New-GcdResourceRecordSet $dnsName1 $rrdataTXT1 "TXT" $ttl1
 
         $rrsetCNAME.Type | Should Match "CNAME"
         $rrsetTXT.Type | Should Match "TXT"

--- a/Google.PowerShell/Dns/GcdManagedZone.cs
+++ b/Google.PowerShell/Dns/GcdManagedZone.cs
@@ -268,7 +268,7 @@ namespace Google.PowerShell.Dns
         /// Force removal of even non-empty ManagedZones (e.g., zones with non-NS/SOA type records).
         /// </para>
         /// </summary>
-        [Parameter(Position = 1, Mandatory = false)]
+        [Parameter(Mandatory = false)]
         public SwitchParameter Force { get; set; }
 
         protected override void ProcessRecord()

--- a/Google.PowerShell/Dns/GcdQuota.cs
+++ b/Google.PowerShell/Dns/GcdQuota.cs
@@ -43,7 +43,7 @@ namespace Google.PowerShell.Dns
         /// Get the Project to return the DNS quota of.
         /// </para>
         /// </summary>
-        [Parameter]
+        [Parameter(Position = 0, Mandatory = false)]
         [ConfigPropertyName(CloudSdkSettings.CommonProperties.Project)]
         public string Project { get; set; }
 

--- a/Tools/CheckCmdletXmlDocs.psm1
+++ b/Tools/CheckCmdletXmlDocs.psm1
@@ -141,6 +141,9 @@ function Check-CmdletDoc() {
             $wroteWarnings = ((DoDeepExampleCheck $docObj) -or $wroteWarnings)
         }
 
+        # Check that all parameters have a valid (non-null, non-whitespace) description. 
+        $wroteWarnings = ((WriteParameterDescriptionWarnings $docObj) -or $wroteWarnings)
+
         if (-not ($wroteWarnings)) {
             Write-Host "PASSED" -ForegroundColor "Green" -BackgroundColor "Black"
         }
@@ -282,6 +285,20 @@ function DoDeepExampleCheck($docObj) {
 
         if ($noOutput.Count -gt 0) {
             "Example number(s) " + ($noOutput -join ", ") + " has(have) no outputs." | Write-Warning
+            $wroteWarnings = $true
+        }
+    }
+
+    return $wroteWarnings
+}
+
+# Check that all parameters for the cmdlet have a valid (non-null, non-whitespace) description. 
+function WriteParameterDescriptionWarnings ($docObj) {
+    $wroteWarnings = $false
+
+    foreach ($parameter in $docObj.parameters.parameter) {
+        if ([String]::IsNullOrWhiteSpace($parameter.description.Text)) {
+            "Parameter `"" + $parameter.name + "`" does not have a valid description." | Write-Warning
             $wroteWarnings = $true
         }
     }

--- a/Tools/CheckCmdletXmlDocs.psm1
+++ b/Tools/CheckCmdletXmlDocs.psm1
@@ -162,8 +162,8 @@ function GetOutputTypeWhitelist ($outputWhitelistDirectory, $allCmdlets) {
         return $null
     } 
     $outputWhitelist = $outputWhitelist.Split(" *`n+", [System.StringSplitOptions]::RemoveEmptyEntries)
-    PrintElementsNotFound $outputWhitelist $allCmdlets.Name "`nThe following cmdlets from the OutputType whitelist were not found: "
-    $outputWhitelist = @($allCmdlets.Name | where { $outputWhitelist -contains $_ })
+    PrintElementsNotFound $outputWhitelist $allCmdlets.Name "`nThe following cmdlets from the OutputType whitelist were not found:"
+    return @($allCmdlets.Name | where { $outputWhitelist -contains $_ })
 }
 
 # Print a list of the elements in sublist that are not part of list. 

--- a/Tools/OutputTypeWhitelist.txt
+++ b/Tools/OutputTypeWhitelist.txt
@@ -1,0 +1,1 @@
+Remove-GcdManagedZone


### PR DESCRIPTION
- Change Dns Pester tests to use positional parameters to make sure they work when not directly named.
- Get-GcdQuota: Make the Project parameter optional but positional since it's the only parameter for the cmdlet. Add associated test. 
- Bring CheckCmdletXmlDocs up to its latest version in the master. 
- Add Remove-GcdManagedZone cmdlet to the OutputTypeWhitelist.txt file. 