### PR TITLE
Enable reading/writing GCS object metadata

### DIFF
--- a/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
@@ -24,6 +24,9 @@ Describe "New-GcsObject" {
         $obj = Get-GcsObject $bucket $objectName
         $obj.Name | Should Be $objectName
         $obj.Size | Should Be 17
+
+        # Confirm it doesn't have any metadata by default.
+        $obj.Metadata.Size | Should Be 0
     }
 
     It "should fail if the file does not exist" {
@@ -172,6 +175,28 @@ Describe "New-GcsObject" {
         $emptyObj = New-GcsObject $bucket "zero-byte-test"
         $emptyObj.Size | Should Be 0
         Remove-GcsObject $emptyObj
+    }
+
+    It "should write metadata" {
+        $obj = New-GcsObject $bucket "metadata-test" -Metadata @{ "alpha" = 1; "beta" = "two"; "Content-Type" = "image/png" }
+        $obj.Metadata.Count = 3
+        $obj.Metadata[0].Key | Should Be "alpha"
+        $obj.Metadata[0].Key | Should Be "1"
+        $obj.Metadata[1].Key | Should Be "beta"
+        $obj.Metadata[1].Key | Should Be "xxx"
+        $obj.Metadata[2].Key | Should Be "Content-Type"
+        $obj.Metadata[2].Key | Should Be "image/png"
+        # Content-Type can be set from metadata.
+        $obj.ContentType | Should Be "image/png"
+        Remove-GcsObject $obj
+    }
+
+    It "will prefer the -ContentType parameter to -Metadata" {
+        $obj = New-GcsObject $bucket "metadata-test" `
+            -ContentType "image/jpeg" `
+            -Metadata @{ "Content-Type" = "image/png" }
+        $obj.ContentType | Should Be "image/jpeg"
+        Remove-GcsObject $obj
     }
 }
 

--- a/Google.PowerShell.Tests/Google.PowerShell.Tests.csproj
+++ b/Google.PowerShell.Tests/Google.PowerShell.Tests.csproj
@@ -35,32 +35,32 @@
       <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis, Version=1.14.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.14.0\lib\net45\Google.Apis.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.15.0\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.14.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.14.0\lib\net45\Google.Apis.Auth.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.15.0\lib\net45\Google.Apis.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.14.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.14.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.15.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Compute.v1, Version=1.13.1.504, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Compute.v1.1.13.1.504\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Compute.v1.dll</HintPath>
+    <Reference Include="Google.Apis.Compute.v1, Version=1.15.0.572, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Compute.v1.1.15.0.572\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Compute.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.14.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Core.1.14.0\lib\net45\Google.Apis.Core.dll</HintPath>
+    <Reference Include="Google.Apis.Core, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Core.1.15.0\lib\net45\Google.Apis.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.PlatformServices, Version=1.14.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.14.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.15.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Storage.v1, Version=1.14.0.547, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Storage.v1.1.14.0.547\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Storage.v1.dll</HintPath>
+    <Reference Include="Google.Apis.Storage.v1, Version=1.15.0.573, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Storage.v1.1.15.0.573\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Storage.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/Google.PowerShell.Tests/app.config
+++ b/Google.PowerShell.Tests/app.config
@@ -8,11 +8,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.14.0.0" newVersion="1.14.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />

--- a/Google.PowerShell.Tests/packages.config
+++ b/Google.PowerShell.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net452" />
-  <package id="Google.Apis" version="1.14.0" targetFramework="net452" />
-  <package id="Google.Apis.Auth" version="1.14.0" targetFramework="net452" />
-  <package id="Google.Apis.Compute.v1" version="1.13.1.504" targetFramework="net452" />
-  <package id="Google.Apis.Core" version="1.14.0" targetFramework="net452" />
-  <package id="Google.Apis.Storage.v1" version="1.14.0.547" targetFramework="net452" />
+  <package id="Google.Apis" version="1.15.0" targetFramework="net452" />
+  <package id="Google.Apis.Auth" version="1.15.0" targetFramework="net452" />
+  <package id="Google.Apis.Compute.v1" version="1.15.0.572" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.15.0" targetFramework="net452" />
+  <package id="Google.Apis.Storage.v1" version="1.15.0.573" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />

--- a/Google.PowerShell/Google.PowerShell.csproj
+++ b/Google.PowerShell/Google.PowerShell.csproj
@@ -40,40 +40,40 @@
       <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.13.1\lib\net45\Google.Apis.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.15.0\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.13.1\lib\net45\Google.Apis.Auth.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.15.0\lib\net45\Google.Apis.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.13.1\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.15.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Compute.v1, Version=1.13.1.504, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Compute.v1.1.13.1.504\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Compute.v1.dll</HintPath>
+    <Reference Include="Google.Apis.Compute.v1, Version=1.15.0.572, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Compute.v1.1.15.0.572\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Compute.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Core.1.13.1\lib\net45\Google.Apis.Core.dll</HintPath>
+    <Reference Include="Google.Apis.Core, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Core.1.15.0\lib\net45\Google.Apis.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis.Dns.v1, Version=1.13.1.517, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.Dns.v1.1.13.1.517\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Dns.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.PlatformServices, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.13.1\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.15.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis.SQLAdmin.v1beta4, Version=1.13.1.494, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.SQLAdmin.v1beta4.1.13.1.494\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.SQLAdmin.v1beta4.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Storage.v1, Version=1.13.1.489, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Storage.v1.1.13.1.489\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Storage.v1.dll</HintPath>
+    <Reference Include="Google.Apis.Storage.v1, Version=1.15.0.573, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Storage.v1.1.15.0.573\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Storage.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net">

--- a/Google.PowerShell/Storage/GcsBucket.cs
+++ b/Google.PowerShell/Storage/GcsBucket.cs
@@ -216,7 +216,7 @@ namespace Google.PowerShell.CloudStorage
         private static readonly Random ActivityIdGenerator = new Random();
 
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// The name of the bucket to remove. This parameter will also accept a Bucket object.
         /// </para>
         /// </summary>
@@ -225,7 +225,7 @@ namespace Google.PowerShell.CloudStorage
         public string Name { get; set; }
 
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// When deleting a bucket with objects still inside, use Force to proceed with the deletion without
         /// a prompt.
         /// </para>
@@ -347,7 +347,7 @@ namespace Google.PowerShell.CloudStorage
     public class TestGcsBucketCmdlet : GcsCmdlet
     {
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// The name of the bucket to test for. This parameter will also accept a Bucket object.
         /// </para>
         /// </summary>

--- a/Google.PowerShell/Storage/GcsBucketLogging.cs
+++ b/Google.PowerShell/Storage/GcsBucketLogging.cs
@@ -30,7 +30,7 @@ namespace Google.PowerShell.CloudStorage
     public class RemoveGcsBucketLoggingCmdlet : GcsCmdlet
     {
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// The name of the bucket to remove logging for. This parameter will also accept a Bucket
         /// object.
         /// </para>
@@ -78,7 +78,7 @@ namespace Google.PowerShell.CloudStorage
     public class WriteGcsBucketLoggingCmdlet : GcsCmdlet
     {
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// The name of the bucket to configure. This parameter will also accept a Bucket object.
         /// </para>
         /// </summary>

--- a/Google.PowerShell/Storage/GcsBucketWebsite.cs
+++ b/Google.PowerShell/Storage/GcsBucketWebsite.cs
@@ -31,7 +31,7 @@ namespace Google.PowerShell.CloudStorage
     public class RemoveGcsBucketWebsiteCmdlet : GcsCmdlet
     {
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// The name of the bucket to remove logging for. This parameter will also accept a Bucket
         /// object.
         /// </para>
@@ -78,7 +78,7 @@ namespace Google.PowerShell.CloudStorage
     public class WriteGcsBucketWebsiteCmdlet : GcsCmdlet
     {
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// The name of the bucket to configure. This parameter will also accept a Bucket object.
         /// </para>
         /// </summary>
@@ -87,7 +87,7 @@ namespace Google.PowerShell.CloudStorage
         public string Name { get; set; }
 
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// Storage object for the "main page" of the website, e.g. what is served from "http://example.com/".
         /// Defaults to "index.html".
         /// </para>
@@ -96,7 +96,7 @@ namespace Google.PowerShell.CloudStorage
         public string MainPageSuffix { get; set; } = "index.html";
 
         /// <summary>
-        /// <para typedef="description">
+        /// <para type="description">
         /// Storage object to render when no appropriate file is found, e.g. what is served from "http://example.com/sadjkffasugmd".
         /// Defaults to "404.html".
         /// </para>

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -115,13 +115,12 @@ namespace Google.PowerShell.CloudStorage
         /// 1. New content type, e.g. a ContentType parameter.
         /// 2. New metadata, e.g. Metadata value specified via parameter.
         /// 3. Default content type to apply (potentially null), e.g. sniffing file content.
-        /// 4. Default content type to apply. e.g. a catch-all like octet-stream.
+        /// If no match is found, will return OctetStreamMimeType.
         /// </summary>
         public string GetContentType(
             string newContentType,
             Dictionary<string, string> newMetadata,
-            string defaultContentType1 = null,
-            string defaultContentType2 = null)
+            string defaultContentType = null)
         {
             if (!String.IsNullOrEmpty(newContentType))
             {
@@ -133,12 +132,12 @@ namespace Google.PowerShell.CloudStorage
                 return newMetadata["Content-Type"];
             }
 
-            if (!String.IsNullOrEmpty(defaultContentType1))
+            if (!String.IsNullOrEmpty(defaultContentType))
             {
-                return defaultContentType1;
+                return defaultContentType;
             }
 
-            return defaultContentType2;
+            return OctetStreamMimeType;
         }
     }
 }

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -4,6 +4,7 @@
 using Google.Apis.Storage.v1;
 using Google.PowerShell.Common;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Google.PowerShell.CloudStorage
@@ -38,6 +39,59 @@ namespace Google.PowerShell.CloudStorage
         protected string GetBaseUri(string bucket, string objectName)
         {
             return $"https://www.googleapis.com/download/storage/v1/b/{bucket}/o/{Uri.EscapeDataString(objectName)}?alt=media";
+        }
+
+        /// <summary>
+        /// Convert a PowerShell HashTable object into a string/string Dictionary.
+        /// </summary>
+        protected Dictionary<string, string> ConvertHashTableToDictionary(Hashtable hashtable)
+        {
+            // Convert a PowerShell HashTable object into a Dictionary<string, string>.
+            var metadataDictionary = new Dictionary<string, string>();
+            if (hashtable == null)
+            {
+                return metadataDictionary;
+            }
+
+            foreach (DictionaryEntry kvp in hashtable)
+            {
+                metadataDictionary.Add(kvp.Key.ToString(), kvp.Value.ToString());
+            }
+            return metadataDictionary;
+        }
+
+        /// <summary>
+        /// Infer the MIME type of a non-qualified file path. Returns null if no match is found.
+        /// </summary>
+        protected string InferContentType(string file)
+        {
+            int index = file.LastIndexOf('.');
+            if (index == -1)
+            {
+                return null;
+            }
+            string extension = file.ToLowerInvariant().Substring(index);
+            // http://www.freeformatter.com/mime-types-list.html
+            switch (extension)
+            {
+                case ".htm":
+                case ".html":
+                    return "text/html";
+                case ".jpg":
+                case ".jpeg":
+                    return "image/jpeg";
+                case ".js":
+                    return "application/javascript";
+                case ".json":
+                    return "application/json";
+                case ".png":
+                    return "image/png";
+                case ".txt":
+                    return "text/plain";
+                case ".zip":
+                    return "application/zip";
+            }
+            return null;
         }
     }
 }

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -61,6 +61,21 @@ namespace Google.PowerShell.CloudStorage
         }
 
         /// <summary>
+        /// Converts an IDictionary into a Dictionary instance. The key value here is properly handling null cases.
+        /// </summary>
+        protected Dictionary<string, string> ConvertToDictionary(IDictionary<string, string> idict)
+        {
+            if (idict == null)
+            {
+                return new Dictionary<string, string>();
+            }
+            else
+            {
+                return new Dictionary<string, string>(idict);
+            }
+        }
+
+        /// <summary>
         /// Infer the MIME type of a non-qualified file path. Returns null if no match is found.
         /// </summary>
         protected string InferContentType(string file)
@@ -92,6 +107,44 @@ namespace Google.PowerShell.CloudStorage
                     return "application/zip";
             }
             return null;
+        }
+
+        /// <summary>
+        /// Return the content type to use for a Cloud Storage object given existing values, defauts, etc. The order of
+        /// precidence is:
+        /// 1. New content type, e.g. a ContentType parameter.
+        /// 2. New metadata, e.g. Metadata value specified via parameter.
+        /// 3. Existing object, to keep its existing content-type
+        /// 4. Default content type #1 to apply. (e.g. sniffing file content.)
+        /// 5. Default content type #2 to apply. (e.g. a catch-all like octet-stream.)
+        /// </summary>
+        public string GetContentType(
+            string newContentType,
+            Dictionary<string, string> newMetadata,
+            Google.Apis.Storage.v1.Data.Object existingObject,
+            string defaultContentType1 = null,
+            string defaultContentType2 = null)
+        {
+            if (!String.IsNullOrEmpty(newContentType))
+            {
+                return newContentType;
+            }
+
+            if (newMetadata != null && newMetadata.ContainsKey("Content-Type"))
+            {
+                return newMetadata["Content-Type"];
+            }
+
+            if (existingObject != null && !String.IsNullOrEmpty(existingObject.ContentType)) {
+                return existingObject.ContentType;
+            }
+
+            if (!String.IsNullOrEmpty(defaultContentType1))
+            {
+                return defaultContentType1;
+            }
+
+            return defaultContentType2;
         }
     }
 }

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -114,14 +114,12 @@ namespace Google.PowerShell.CloudStorage
         /// precidence is:
         /// 1. New content type, e.g. a ContentType parameter.
         /// 2. New metadata, e.g. Metadata value specified via parameter.
-        /// 3. Existing object, to keep its existing content-type
-        /// 4. Default content type #1 to apply. (e.g. sniffing file content.)
-        /// 5. Default content type #2 to apply. (e.g. a catch-all like octet-stream.)
+        /// 3. Default content type to apply (potentially null), e.g. sniffing file content.
+        /// 4. Default content type to apply. e.g. a catch-all like octet-stream.
         /// </summary>
         public string GetContentType(
             string newContentType,
             Dictionary<string, string> newMetadata,
-            Google.Apis.Storage.v1.Data.Object existingObject,
             string defaultContentType1 = null,
             string defaultContentType2 = null)
         {
@@ -133,10 +131,6 @@ namespace Google.PowerShell.CloudStorage
             if (newMetadata != null && newMetadata.ContainsKey("Content-Type"))
             {
                 return newMetadata["Content-Type"];
-            }
-
-            if (existingObject != null && !String.IsNullOrEmpty(existingObject.ContentType)) {
-                return existingObject.ContentType;
             }
 
             if (!String.IsNullOrEmpty(defaultContentType1))

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -44,7 +44,7 @@ namespace Google.PowerShell.CloudStorage
         /// <summary>
         /// Convert a PowerShell HashTable object into a string/string Dictionary.
         /// </summary>
-        protected Dictionary<string, string> ConvertHashTableToDictionary(Hashtable hashtable)
+        protected Dictionary<string, string> ConvertToDictionary(Hashtable hashtable)
         {
             // Convert a PowerShell HashTable object into a Dictionary<string, string>.
             var metadataDictionary = new Dictionary<string, string>();
@@ -55,7 +55,7 @@ namespace Google.PowerShell.CloudStorage
 
             foreach (DictionaryEntry kvp in hashtable)
             {
-                metadataDictionary.Add(kvp.Key.ToString(), kvp.Value.ToString());
+                metadataDictionary.Add(kvp.Key.ToString(), kvp.Value?.ToString());
             }
             return metadataDictionary;
         }

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -46,7 +46,6 @@ namespace Google.PowerShell.CloudStorage
         /// </summary>
         protected Dictionary<string, string> ConvertToDictionary(Hashtable hashtable)
         {
-            // Convert a PowerShell HashTable object into a Dictionary<string, string>.
             var metadataDictionary = new Dictionary<string, string>();
             if (hashtable == null)
             {
@@ -61,7 +60,8 @@ namespace Google.PowerShell.CloudStorage
         }
 
         /// <summary>
-        /// Converts an IDictionary into a Dictionary instance. The key value here is properly handling null cases.
+        /// Converts an IDictionary into a Dictionary instance. (This method is preferred over passing it to
+        /// the constructor for Dictionary since this will handle the null case.)
         /// </summary>
         protected Dictionary<string, string> ConvertToDictionary(IDictionary<string, string> idict)
         {

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -156,9 +156,7 @@ namespace Google.PowerShell.CloudStorage
         /// Provide a predefined ACL to the object. e.g. "publicRead" where the project owner gets
         /// OWNER access, and allUsers get READER access.
         /// </para>
-        /// <para type="description">
-        /// See: https://cloud.google.com/storage/docs/json_api/v1/objects/insert
-        /// </para>
+        /// <para type="link" uri="(https://cloud.google.com/storage/docs/json_api/v1/objects/insert)">[API Documentation]</para>
         /// </summary>
         [Parameter(Mandatory = false)]
         public PredefinedAclEnum? PredefinedAcl { get; set; }

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -220,8 +220,7 @@ namespace Google.PowerShell.CloudStorage
             Stream contentStream = null;
             if (!string.IsNullOrEmpty(File))
             {
-                objContentType = GetContentType(
-                    ContentType, metadataDict, InferContentType(File), OctetStreamMimeType);
+                objContentType = GetContentType(ContentType, metadataDict, InferContentType(File));
                 string qualifiedPath = GetFullPath(File);
                 if (!System.IO.File.Exists(qualifiedPath))
                 {
@@ -233,7 +232,7 @@ namespace Google.PowerShell.CloudStorage
             {
                 // We store string data as UTF-8, which is different from .NET's default encoding
                 // (UTF-16). But this simplifies several other issues.
-                objContentType = GetContentType(ContentType, metadataDict, null, UTF8TextMimeType);
+                objContentType = GetContentType(ContentType, metadataDict, UTF8TextMimeType);
                 byte[] contentBuffer = Encoding.UTF8.GetBytes(Contents);
                 contentStream = new MemoryStream(contentBuffer);
             }
@@ -851,8 +850,7 @@ namespace Google.PowerShell.CloudStorage
                     }
                 }
 
-                string contentType = GetContentType(
-                    ContentType, existingObjectMetadata, existingGcsObject?.ContentType, OctetStreamMimeType);
+                string contentType = GetContentType(ContentType, existingObjectMetadata, existingGcsObject?.ContentType);
 
                 // Rewriting GCS objects is done by simply creating a new object with the
                 // same name. (i.e. this is functionally identical to New-GcsObject.)

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -212,7 +212,7 @@ namespace Google.PowerShell.CloudStorage
             base.ProcessRecord();
             var service = GetStorageService();
 
-            Dictionary<string, string> metadataDict = ConvertHashTableToDictionary(Metadata);
+            Dictionary<string, string> metadataDict = ConvertToDictionary(Metadata);
 
             // Content type to use for the new object.
             string objContentType = null;
@@ -833,12 +833,15 @@ namespace Google.PowerShell.CloudStorage
                     getReq.Projection = ObjectsResource.GetRequest.ProjectionEnum.Full;
 
                     existingGcsObject = getReq.Execute();
-
+                    existingObjectMetadata = ConvertToDictionary(existingGcsObject.Metadata);
                     // If the object already has metadata associated with it, we first PATCH the new metadata into the
                     // existing object. Otherwise we would reimplement "metadata merging" logic, and probably get it wrong.
-                    Object existingGcsObjectUpdatedMetadata = UpdateObjectMetadata(
-                        service, existingGcsObject, ConvertToDictionary(existingGcsObject.Metadata));
-                    existingObjectMetadata = ConvertToDictionary(existingGcsObjectUpdatedMetadata.Metadata);
+                    if (Metadata != null)
+                    {
+                        Object existingGcsObjectUpdatedMetadata = UpdateObjectMetadata(
+                            service, existingGcsObject, ConvertToDictionary(Metadata));
+                        existingObjectMetadata = ConvertToDictionary(existingGcsObjectUpdatedMetadata.Metadata);
+                    }
                 }
                 catch (GoogleApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
                 {

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -221,7 +221,7 @@ namespace Google.PowerShell.CloudStorage
             if (!string.IsNullOrEmpty(File))
             {
                 objContentType = GetContentType(
-                    ContentType, metadataDict, null, InferContentType(File), OctetStreamMimeType);
+                    ContentType, metadataDict, InferContentType(File), OctetStreamMimeType);
                 string qualifiedPath = GetFullPath(File);
                 if (!System.IO.File.Exists(qualifiedPath))
                 {
@@ -851,7 +851,8 @@ namespace Google.PowerShell.CloudStorage
                     }
                 }
 
-                string contentType = GetContentType(ContentType, existingObjectMetadata, existingGcsObject);
+                string contentType = GetContentType(
+                    ContentType, existingObjectMetadata, existingGcsObject?.ContentType, OctetStreamMimeType);
 
                 // Rewriting GCS objects is done by simply creating a new object with the
                 // same name. (i.e. this is functionally identical to New-GcsObject.)

--- a/Google.PowerShell/app.config
+++ b/Google.PowerShell/app.config
@@ -20,11 +20,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.13.1.0" newVersion="1.13.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.13.1.0" newVersion="1.13.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.15.0.0" newVersion="1.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />

--- a/Google.PowerShell/packages.config
+++ b/Google.PowerShell/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net452" />
-  <package id="Google.Apis" version="1.13.1" targetFramework="net452" />
-  <package id="Google.Apis.Auth" version="1.13.1" targetFramework="net452" />
-  <package id="Google.Apis.Compute.v1" version="1.13.1.504" targetFramework="net452" />
-  <package id="Google.Apis.Core" version="1.13.1" targetFramework="net452" />
+  <package id="Google.Apis" version="1.15.0" targetFramework="net452" />
+  <package id="Google.Apis.Auth" version="1.15.0" targetFramework="net452" />
+  <package id="Google.Apis.Compute.v1" version="1.15.0.572" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.15.0" targetFramework="net452" />
   <package id="Google.Apis.Dns.v1" version="1.13.1.517" targetFramework="net452" />
   <package id="Google.Apis.SQLAdmin.v1beta4" version="1.13.1.494" targetFramework="net452" />
-  <package id="Google.Apis.Storage.v1" version="1.13.1.489" targetFramework="net452" />
+  <package id="Google.Apis.Storage.v1" version="1.15.0.573" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />


### PR DESCRIPTION
This PR adds the ability to write/update GCS object metadata in the `New-GcsObject` and `Write-GcsObject` cmdlets. (You were always able to read it.)

This PR was a huge PITA because the GCS API has two places you can specify the `ContentType` for an object. So extra work is done to make sure that we always prefer the content type you specify via the parameter, and ignore the value from metadata if there is a conflict.

Also, PowerShell dictionaries are of the `Hashtable` which are subtltey different than the type we use internally, `Dictionary<string, string>`, and what the API expects, `IDictionary<string, string>`. However, a few convenience methods were able to blur those lines sufficiently.

This PR also updates the NuGet package versions. Pester was not able to run the tests until the references were updated. (I cannot explain why that is the case.)

Fixes issue #164, and #201.