### PR TITLE
Make Set-GceInstance -RemoveDisk take a Disk object.

### DIFF
--- a/Google.PowerShell.IntegrationTests/Compute/Compute.GceInstance.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Compute/Compute.GceInstance.Tests.ps1
@@ -429,7 +429,7 @@ Describe "Set-GceInstance" {
             ($instanceObj.Disks | Where {$_.DeviceName -eq $newDiskName}).Count | Should Be 1
 
             Set-GceInstance -Project $project -Zone $zone2 $instance -RemoveDisk $newDiskName,
-                $newDiskName2, $newDiskName3
+                $newDisk2, $newDiskName3
             (Get-GceInstance -Project $project -Zone $zone2 $instance).Disks.Count | Should Be 1
         }
 

--- a/Google.PowerShell/Common/GcloudAttributes.cs
+++ b/Google.PowerShell/Common/GcloudAttributes.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
 
@@ -115,6 +117,39 @@ namespace Google.PowerShell.Common
 
                 field.SetValue(instance, settingsValue);
             }
+        }
+    }
+    /// <summary>
+    /// This attribute allows an arry parameter to accept multiple types by replacing a target type with the 
+    /// value of a specified property. If the array element is not of the target type, it will not be changed.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [ArrayPropertyTransform(typeof(Zone), nameof(Zone.Name))]
+    /// public string[] ZoneName { get; set; }
+    /// </code>
+    /// Transforms any Zone objects given to the ZoneName Parameter into zoneObject.Name
+    /// </example>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
+    public class ArrayPropertyTransformAttribute : ArgumentTransformationAttribute
+    {
+        private PropertyByTypeTransformationAttribute typeTransformationAttribute;
+
+        public ArrayPropertyTransformAttribute(Type typeToTransform, string property)
+        {
+            typeTransformationAttribute = new PropertyByTypeTransformationAttribute
+            {
+                Property = property,
+                TypeToTransform = typeToTransform
+            };
+        }
+
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        {
+            var enumerable = inputData as IEnumerable<object> ?? new[] { inputData };
+            return enumerable.Select(
+                    inputElement => typeTransformationAttribute.Transform(engineIntrinsics, inputElement)
+                    ).ToArray();
         }
     }
 }

--- a/Google.PowerShell/Common/GcloudAttributes.cs
+++ b/Google.PowerShell/Common/GcloudAttributes.cs
@@ -120,7 +120,7 @@ namespace Google.PowerShell.Common
         }
     }
     /// <summary>
-    /// This attribute allows an arry parameter to accept multiple types by replacing a target type with the 
+    /// This attribute allows an array parameter to accept multiple types by replacing a target type with the 
     /// value of a specified property. If the array element is not of the target type, it will not be changed.
     /// </summary>
     /// <example>

--- a/Google.PowerShell/Compute/GceInstanceCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceCmdlets.cs
@@ -1083,6 +1083,7 @@ namespace Google.PowerShell.ComputeEngine
         /// </summary>
         [Parameter(ParameterSetName = ParameterSetNames.Disk)]
         [Parameter(ParameterSetName = ParameterSetNames.DiskByObject)]
+        [ArrayPropertyTransform(typeof(Disk), nameof(Disk.Name))]
         public string[] RemoveDisk { get; set; } = { };
 
         /// <summary>


### PR DESCRIPTION
Adding this attribute allows -RemoveDisk to take a disk object, as well as a string name.