### PR TITLE
Formatting, Flesh out some examples/docs, Add website code sample for DNS, Add ValidateSet to Filter in Get-GcdRrset

### DIFF
--- a/Google.PowerShell.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/Google.PowerShell.IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System.Reflection;

--- a/Google.PowerShell.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/Google.PowerShell.IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/Google.PowerShell.Tests/Common/CloudSdkSettingsTests.cs
+++ b/Google.PowerShell.Tests/Common/CloudSdkSettingsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Google.PowerShell.Tests/Common/CloudSdkSettingsTests.cs
+++ b/Google.PowerShell.Tests/Common/CloudSdkSettingsTests.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System;

--- a/Google.PowerShell.Tests/Common/ConfigDefaultAttributeTest.cs
+++ b/Google.PowerShell.Tests/Common/ConfigDefaultAttributeTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.PowerShell.Common;
 using NUnit.Core;
 using NUnit.Framework;

--- a/Google.PowerShell.Tests/Common/ConfigDefaultAttributeTest.cs
+++ b/Google.PowerShell.Tests/Common/ConfigDefaultAttributeTest.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.PowerShell.Common;

--- a/Google.PowerShell.Tests/Common/GCloudCmdletTests.cs
+++ b/Google.PowerShell.Tests/Common/GCloudCmdletTests.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System;

--- a/Google.PowerShell.Tests/Common/GCloudCmdletTests.cs
+++ b/Google.PowerShell.Tests/Common/GCloudCmdletTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System;
 using System.Management.Automation;
 using System.Collections.Generic;

--- a/Google.PowerShell.Tests/Common/MeasurementServiceProtocolTests.cs
+++ b/Google.PowerShell.Tests/Common/MeasurementServiceProtocolTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Google.PowerShell.Tests/Common/MeasurementServiceProtocolTests.cs
+++ b/Google.PowerShell.Tests/Common/MeasurementServiceProtocolTests.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System;

--- a/Google.PowerShell.Tests/Common/PropertyByTypeTransformationAttributeTest.cs
+++ b/Google.PowerShell.Tests/Common/PropertyByTypeTransformationAttributeTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System.Management.Automation;
 using Google.PowerShell.Common;
 using NUnit.Framework;

--- a/Google.PowerShell.Tests/Common/PropertyByTypeTransformationAttributeTest.cs
+++ b/Google.PowerShell.Tests/Common/PropertyByTypeTransformationAttributeTest.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System.Management.Automation;
@@ -15,43 +17,43 @@ namespace Google.PowerShell.Tests.Common.ComputeEngine
     [TestFixture]
     public class PropertyByTypeTransformationAttributeTest
     {
-        private static string _testString = "testString";
+        private static string s_testString = "testString";
 
         [Test]
         public void TestStringPassThrough()
         {
             var attribute = new PropertyByTypeTransformationAttribute { Property = "name", TypeToTransform = typeof(TestType) };
-            object result = attribute.Transform(null, _testString);
-            Assert.AreEqual(result, _testString);
+            object result = attribute.Transform(null, s_testString);
+            Assert.AreEqual(result, s_testString);
         }
 
         [Test]
         public void TestProjectConversion()
         {
-            TestType project = new TestType { Name = _testString };
+            TestType project = new TestType { Name = s_testString };
             var attribute = new PropertyByTypeTransformationAttribute { Property = "name", TypeToTransform = typeof(TestType) };
             object result = attribute.Transform(null, project);
-            Assert.AreEqual(_testString, result);
+            Assert.AreEqual(s_testString, result);
         }
 
         [Test]
         public void TestPSObjectConversion()
         {
-            TestType project = new TestType { Name = _testString };
+            TestType project = new TestType { Name = s_testString };
             PSObject obj = new PSObject(project);
             var attribute = new PropertyByTypeTransformationAttribute { Property = "name", TypeToTransform = typeof(TestType) };
             object result = attribute.Transform(null, obj);
-            Assert.AreEqual(result, _testString);
+            Assert.AreEqual(result, s_testString);
         }
 
         [Test]
         public void TestDeepPSObjectConversion()
         {
-            TestType project = new TestType { Name = _testString };
+            TestType project = new TestType { Name = s_testString };
             PSObject obj = new PSObject(project);
             var attribute = new PropertyByTypeTransformationAttribute { Property = "name", TypeToTransform = typeof(TestType) };
             object result = attribute.Transform(null, new PSObject(obj));
-            Assert.AreEqual(result, _testString);
+            Assert.AreEqual(result, s_testString);
         }
     }
 }

--- a/Google.PowerShell.Tests/Compute/InstanceMetadataConverterTest.cs
+++ b/Google.PowerShell.Tests/Compute/InstanceMetadataConverterTest.cs
@@ -1,4 +1,7 @@
-﻿using Google.Apis.Compute.v1.Data;
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.ComputeEngine;
 using NUnit.Framework;
 using System.Collections;

--- a/Google.PowerShell.Tests/Properties/AssemblyInfo.cs
+++ b/Google.PowerShell.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System.Reflection;

--- a/Google.PowerShell.Tests/Properties/AssemblyInfo.cs
+++ b/Google.PowerShell.Tests/Properties/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/Google.PowerShell/Common/CloudSdkSettings.cs
+++ b/Google.PowerShell/Common/CloudSdkSettings.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System;

--- a/Google.PowerShell/Common/CloudSdkSettings.cs
+++ b/Google.PowerShell/Common/CloudSdkSettings.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/Google.PowerShell/Common/GcloudAttributes.cs
+++ b/Google.PowerShell/Common/GcloudAttributes.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System;

--- a/Google.PowerShell/Common/GcloudAttributes.cs
+++ b/Google.PowerShell/Common/GcloudAttributes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System;
 using System.Management.Automation;
 using System.Reflection;

--- a/Google.PowerShell/Common/GcloudCmdlet.cs
+++ b/Google.PowerShell/Common/GcloudCmdlet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System;

--- a/Google.PowerShell/Common/GcloudCmdlet.cs
+++ b/Google.PowerShell/Common/GcloudCmdlet.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Auth.OAuth2;

--- a/Google.PowerShell/Common/MeasurementProtocolService.cs
+++ b/Google.PowerShell/Common/MeasurementProtocolService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/Google.PowerShell/Common/MeasurementProtocolService.cs
+++ b/Google.PowerShell/Common/MeasurementProtocolService.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System;

--- a/Google.PowerShell/Compute/GceAddressCmdlets.cs
+++ b/Google.PowerShell/Compute/GceAddressCmdlets.cs
@@ -1,4 +1,7 @@
-﻿using Google.Apis.Compute.v1;
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using System.Collections.Generic;

--- a/Google.PowerShell/Compute/GceAttachedDiskConfigCmdlets.cs
+++ b/Google.PowerShell/Compute/GceAttachedDiskConfigCmdlets.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1.Data;
 using System.Management.Automation;
 

--- a/Google.PowerShell/Compute/GceAttachedDiskConfigCmdlets.cs
+++ b/Google.PowerShell/Compute/GceAttachedDiskConfigCmdlets.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1.Data;

--- a/Google.PowerShell/Compute/GceCmdlet.cs
+++ b/Google.PowerShell/Compute/GceCmdlet.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1;
@@ -149,7 +151,8 @@ namespace Google.PowerShell.ComputeEngine
             public Action Callback { get; }
 
             public LocalOperation(string project, string local, Operation operation)
-                : this(project, local, operation, () => { }) { }
+                : this(project, local, operation, () => { })
+            { }
 
             public LocalOperation(string project, string local, Operation operation, Action callback)
             {
@@ -174,7 +177,8 @@ namespace Google.PowerShell.ComputeEngine
             public Action Callback { get; }
 
             public GlobalOperation(string project, Operation operation)
-                : this(project, operation, () => { }) { }
+                : this(project, operation, () => { })
+            { }
 
             public GlobalOperation(string project, Operation operation, Action callback)
             {

--- a/Google.PowerShell/Compute/GceCmdlet.cs
+++ b/Google.PowerShell/Compute/GceCmdlet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Compute/GceDisk.cs
+++ b/Google.PowerShell/Compute/GceDisk.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Compute/GceDisk.cs
+++ b/Google.PowerShell/Compute/GceDisk.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1;
@@ -255,7 +257,6 @@ namespace Google.PowerShell.ComputeEngine
                 Disk disk = getReq.Execute();
                 WriteObject(disk);
             });
-
         }
     }
 

--- a/Google.PowerShell/Compute/GceFirewallCmdlets.cs
+++ b/Google.PowerShell/Compute/GceFirewallCmdlets.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1.Data;

--- a/Google.PowerShell/Compute/GceFirewallCmdlets.cs
+++ b/Google.PowerShell/Compute/GceFirewallCmdlets.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using System.Collections.Generic;

--- a/Google.PowerShell/Compute/GceFirewallProtocolCmdlet.cs
+++ b/Google.PowerShell/Compute/GceFirewallProtocolCmdlet.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1.Data;

--- a/Google.PowerShell/Compute/GceFirewallProtocolCmdlet.cs
+++ b/Google.PowerShell/Compute/GceFirewallProtocolCmdlet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1.Data;
 using System.Collections.Generic;
 using System.Management.Automation;

--- a/Google.PowerShell/Compute/GceImageCmdlets.cs
+++ b/Google.PowerShell/Compute/GceImageCmdlets.cs
@@ -1,4 +1,7 @@
-﻿using Google.Apis.Compute.v1;
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using System;
@@ -20,7 +23,7 @@ namespace Google.PowerShell.ComputeEngine
     [Cmdlet(VerbsCommon.Get, "GceImage", DefaultParameterSetName = ParameterSetNames.OfProject)]
     public class GetGceImageCmdlets : GceCmdlet
     {
-        private static readonly string[] DefaultProjects = {
+        private static readonly string[] s_defaultProjects = {
                 "centos-cloud", "coreos-cloud", "debian-cloud", "debian-cloud",
                 "rhel-cloud", "suse-cloud", "ubuntu-os-cloud", "windows-cloud"
             };
@@ -55,7 +58,7 @@ namespace Google.PowerShell.ComputeEngine
         /// </para>
         /// </summary>
         [Parameter(Position = 1)]
-        public string[] Project { get; set; } = DefaultProjects;
+        public string[] Project { get; set; } = s_defaultProjects;
 
         /// <summary>
         /// <para type="description">

--- a/Google.PowerShell/Compute/GceInstanceCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceCmdlets.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1;

--- a/Google.PowerShell/Compute/GceInstanceCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceCmdlets.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Compute/GceInstanceConfigCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceConfigCmdlets.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1.Data;
@@ -20,7 +22,6 @@ namespace Google.PowerShell.ComputeEngine
     [Cmdlet(VerbsCommon.New, "GceInstanceConfig")]
     public class NewGceInstanceConfigCmdlet : GceInstanceDescriptionCmdlet
     {
-
         /// <summary>
         /// <para type="description">
         /// The name of the instance. The name must be 1-63 characters long and

--- a/Google.PowerShell/Compute/GceInstanceConfigCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceConfigCmdlets.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using System.Collections;

--- a/Google.PowerShell/Compute/GceInstanceDescriptionCmdlet.cs
+++ b/Google.PowerShell/Compute/GceInstanceDescriptionCmdlet.cs
@@ -1,3 +1,6 @@
+// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 using Google.Apis.Compute.v1.Data;
 using System.Collections;
 using System.Collections.Generic;
@@ -145,7 +148,6 @@ namespace Google.PowerShell.ComputeEngine
 
             if (BootDiskImage != null)
             {
-
                 disks.Add(new AttachedDisk
                 {
                     Boot = true,

--- a/Google.PowerShell/Compute/GceInstanceTemplateCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceTemplateCmdlets.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1;

--- a/Google.PowerShell/Compute/GceInstanceTemplateCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceTemplateCmdlets.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Compute/GceMachineType.cs
+++ b/Google.PowerShell/Compute/GceMachineType.cs
@@ -1,4 +1,7 @@
-﻿using Google.Apis.Compute.v1;
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using Google.PowerShell.ComputeEngine;

--- a/Google.PowerShell/Compute/GceManagedInstanceGroupCmdlets.cs
+++ b/Google.PowerShell/Compute/GceManagedInstanceGroupCmdlets.cs
@@ -1,4 +1,7 @@
-﻿using Google.Apis.Compute.v1;
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using Google.PowerShell.ComputeEngine;
@@ -178,7 +181,6 @@ namespace Google.PowerShell.Compute
                 }
                 request.PageToken = response.NextPageToken;
             } while (!Stopping && request.PageToken != null);
-
         }
 
         private IEnumerable<InstanceGroupManager> GetProjectGroups()
@@ -336,7 +338,6 @@ namespace Google.PowerShell.Compute
                         TargetPools = TargetPool,
                         NamedPorts = BuildNamedPorts(),
                         TargetSize = TargetSize
-
                     };
                     break;
                 case ParameterSetNames.ByObject:

--- a/Google.PowerShell/Compute/GceNetworkCmdlets.cs
+++ b/Google.PowerShell/Compute/GceNetworkCmdlets.cs
@@ -1,4 +1,7 @@
-﻿using Google.Apis.Compute.v1;
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using Google.PowerShell.ComputeEngine;
@@ -45,7 +48,6 @@ namespace Google.PowerShell.Compute
             {
                 WriteObject(Service.Networks.Get(Project, Name).Execute());
             }
-
         }
 
         private IEnumerable<Network> GetAllProjectNetworks()

--- a/Google.PowerShell/Compute/GceRouteCmdlets.cs
+++ b/Google.PowerShell/Compute/GceRouteCmdlets.cs
@@ -1,4 +1,7 @@
-﻿using Google.Apis.Compute.v1;
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using Google.PowerShell.ComputeEngine;

--- a/Google.PowerShell/Compute/GceServiceAccountConfigCmdlets.cs
+++ b/Google.PowerShell/Compute/GceServiceAccountConfigCmdlets.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1.Data;
@@ -225,7 +227,7 @@ namespace Google.PowerShell.ComputeEngine
         /// Because this cmdlet uses MyInvocation.BoundParameters to get the parameter values, we can't just
         /// set the respective porperties to their default values, as they would not be bound.
         /// </summary>
-        private static readonly IDictionary<string, object> DefaultParameterValues =
+        private static readonly IDictionary<string, object> s_defaultParameterValues =
             new Dictionary<string, object>
             {
                 {"CloudLogging", ReadWrite.Write},
@@ -233,8 +235,7 @@ namespace Google.PowerShell.ComputeEngine
                 {"ServiceControl", true},
                 {"ServiceManagement", true},
                 {"Storage", ReadWrite.Read}
-
-            };
+};
 
         /// <summary>
         /// Maps parameter names to a sub dictionary. each sub dictionary maps parameter values to their scope
@@ -245,7 +246,7 @@ namespace Google.PowerShell.ComputeEngine
         /// get the related sope with 
         /// <code>string scope = NamevalueScopeMap["BigtableAdmin"][BigTableAdminEnum.Tables]</code>
         /// </example>
-        private static readonly IDictionary<string, IDictionary<object, string>> NameValueScopeMap =
+        private static readonly IDictionary<string, IDictionary<object, string>> s_nameValueScopeMap =
             new Dictionary<string, IDictionary<object, string>>
             {
                 {
@@ -362,7 +363,7 @@ namespace Google.PowerShell.ComputeEngine
             }
 
             // Add scopes for parameters with default values that were not bound.
-            foreach (KeyValuePair<string, object> defaultParameter in DefaultParameterValues)
+            foreach (KeyValuePair<string, object> defaultParameter in s_defaultParameterValues)
             {
                 if (!MyInvocation.BoundParameters.ContainsKey(defaultParameter.Key))
                 {
@@ -388,11 +389,11 @@ namespace Google.PowerShell.ComputeEngine
             const string baseUri = "https://www.googleapis.com/auth/";
 
             string scopeType = parameter.Key;
-            if (NameValueScopeMap.ContainsKey(scopeType))
+            if (s_nameValueScopeMap.ContainsKey(scopeType))
             {
-                if (NameValueScopeMap[scopeType].ContainsKey(parameter.Value))
+                if (s_nameValueScopeMap[scopeType].ContainsKey(parameter.Value))
                 {
-                    string scopeString = NameValueScopeMap[scopeType][parameter.Value];
+                    string scopeString = s_nameValueScopeMap[scopeType][parameter.Value];
                     scopes.Add($"{baseUri}{scopeString}");
                 }
             }

--- a/Google.PowerShell/Compute/GceServiceAccountConfigCmdlets.cs
+++ b/Google.PowerShell/Compute/GceServiceAccountConfigCmdlets.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using System.Collections.Generic;

--- a/Google.PowerShell/Compute/GceSnapshotCmdlets.cs
+++ b/Google.PowerShell/Compute/GceSnapshotCmdlets.cs
@@ -1,4 +1,7 @@
-﻿using Google.Apis.Compute.v1;
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Google.Apis.Compute.v1;
 using Google.Apis.Compute.v1.Data;
 using Google.PowerShell.Common;
 using Google.PowerShell.ComputeEngine;

--- a/Google.PowerShell/Compute/GoogleComputeOperationException.cs
+++ b/Google.PowerShell/Compute/GoogleComputeOperationException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1.Data;
 using System;
 using System.Linq;

--- a/Google.PowerShell/Compute/GoogleComputeOperationException.cs
+++ b/Google.PowerShell/Compute/GoogleComputeOperationException.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1.Data;

--- a/Google.PowerShell/Compute/InstanceMetadataConverter.cs
+++ b/Google.PowerShell/Compute/InstanceMetadataConverter.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Compute.v1.Data;

--- a/Google.PowerShell/Compute/InstanceMetadataConverter.cs
+++ b/Google.PowerShell/Compute/InstanceMetadataConverter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Compute.v1.Data;
 using System.Collections;
 using System.Collections.Generic;

--- a/Google.PowerShell/Dns/GcdChange.cs
+++ b/Google.PowerShell/Dns/GcdChange.cs
@@ -114,7 +114,7 @@ namespace Google.PowerShell.Dns
     /// Add a new Change to a ManagedZone of a Project.
     /// </para>
     /// <para type="description">
-    /// Create, execute, and return a new Change within a specified ManagedZone of a Project.
+    /// Create, execute, and return a new Change request within a specified ManagedZone of a Project.
     /// </para>
     /// <para type="description">
     /// If a Project is specified, will instead create the Change in the specified ManagedZone governed by that 
@@ -122,31 +122,44 @@ namespace Google.PowerShell.Dns
     /// Either a Change request or ResourceRecordSet[] to add/remove can be given as input.
     /// </para>
     /// <example>
-    ///   <para>Add the Change request $change1 to the ManagedZone "test1" in the Project "testing."</para>
-    ///   <para><code>PS C:\> Add-GcdChange -Project "testing" -Zone "test1" -ChangeRequest $change1</code></para>
+    ///   <para> 
+    ///   Add a new Change that adds a new A-type ResourceRecordSet, $newARecord, and removes an existing CNAME-type 
+    ///   record, $oldCNAMERecord, from the ManagedZone "test1" (governing "gcloudexample1.com.") in the Project 
+    ///   "testing."
+    ///   </para>
+    ///   <para>
+    ///     <code>
+    ///     PS C:\> $newARecord = New-GcdResourceRecordSet -Name "gcloudexample1.com." -Rrdata "104.1.34.167"
+    ///     </code>
+    ///     <code> PS C:\> $oldCNAMERecord = (Get-GcdResourceRecordSet -Zone "test1" -Filter "CNAME")[0]</code>
+    ///     <code>
+    ///     PS C:\> Add-GcdChange -Project "testing" -Zone "test1" -Add $newARecord -Remove $oldCNAMERecord
+    ///     </code>
+    ///   </para>
     ///   <br></br>
-    ///   <para>Additions :</para>
-    ///   <para>Deletions : {gcloudexample1.com.}</para>
-    ///   <para>Id        : 1</para>
+    ///   <para>Additions : {gcloudexample1.com.}</para>
+    ///   <para>Deletions : {www.gcloudexample1.com.}</para>
+    ///   <para>Id        : 3</para>
     ///   <para>Kind      : dns#change</para>
     ///   <para>StartTime : 2016-06-29T16:30:50.670Z</para> 
     ///   <para>Status    : done</para> 
     ///   <para>ETag      :</para>
     /// </example>
     /// <example>
-    ///   <para> 
-    ///   Add a new Change that adds the ResourceRecordSets $addRrsets and removes the ResourceRecordSets $rmRrsets
-    ///   from the ManagedZone "test1" in the Project "testing."
+    ///   <para>
+    ///   Add the Change request $change2 to the ManagedZone "test1" in the Project "testing," where $change2 is a 
+    ///   previously executed Change request in ManagedZone "test1" that we want to apply again.
     ///   </para>
     ///   <para>
-    ///     <code>PS C:\> Add-GcdChange -Project "testing" -Zone "test1" -Add $addRrsets -Remove $rmRrsets</code>
+    ///     <code>PS C:\> $change2 = Get-GcdChange -Project "testing" -Zone "test1" -ChangeId 2 </code>
+    ///     <code>PS C:\> Add-GcdChange -Project "testing" -Zone "test1" -ChangeRequest $change2</code>
     ///   </para>
     ///   <br></br>
-    ///   <para>Additions : {gcloudexample1.com.}</para>
-    ///   <para>Deletions : {a.gcloudexample1.com.}</para>
-    ///   <para>Id        : 1</para>
+    ///   <para>Additions :</para>
+    ///   <para>Deletions : {gcloudexample1.com.}</para>
+    ///   <para>Id        : 4</para>
     ///   <para>Kind      : dns#change</para>
-    ///   <para>StartTime : 2016-06-29T16:30:50.670Z</para> 
+    ///   <para>StartTime : 2016-06-29T18:30:50.670Z</para> 
     ///   <para>Status    : done</para> 
     ///   <para>ETag      :</para>
     /// </example>
@@ -199,7 +212,7 @@ namespace Google.PowerShell.Dns
 
         /// <summary>
         /// <para type="description">
-        /// Get the ResourceRecordSets to add for this Change.
+        /// Get the ResourceRecordSet(s) to add for this Change.
         /// </para>
         /// </summary>
         [Parameter(ParameterSetName = ParameterSetNames.AddRm, Mandatory = false)]
@@ -207,7 +220,7 @@ namespace Google.PowerShell.Dns
 
         /// <summary>
         /// <para type="description">
-        /// Get the ResourceRecordSets to remove (must exactly match existing ones) for this Change.
+        /// Get the ResourceRecordSet(s) to remove (must exactly match existing ones) for this Change.
         /// </para>
         /// </summary>
         [Alias("Rm")]

--- a/Google.PowerShell/Dns/GcdChange.cs
+++ b/Google.PowerShell/Dns/GcdChange.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Dns.v1;
@@ -163,7 +165,7 @@ namespace Google.PowerShell.Dns
 
         private class LocalErrorMessages
         {
-            public const string NeedChangeContent = 
+            public const string NeedChangeContent =
                 "Must specify at least 1 non-null, non-empty value for Add or Remove.";
         }
 
@@ -191,7 +193,7 @@ namespace Google.PowerShell.Dns
         /// </para>
         /// </summary>
         [Alias("Change")]
-        [Parameter(ParameterSetName = ParameterSetNames.ChangeRequest, Position = 1, Mandatory = true, 
+        [Parameter(ParameterSetName = ParameterSetNames.ChangeRequest, Position = 1, Mandatory = true,
             ValueFromPipeline = true)]
         public Change ChangeRequest { get; set; }
 
@@ -243,7 +245,7 @@ namespace Google.PowerShell.Dns
                     throw UnknownParameterSetException;
             }
 
-            ChangesResource.CreateRequest changeCreateRequest = 
+            ChangesResource.CreateRequest changeCreateRequest =
                 Service.Changes.Create(changeContent, Project, Zone);
             Change changeResponse = changeCreateRequest.Execute();
             WriteObject(changeResponse);

--- a/Google.PowerShell/Dns/GcdChange.cs
+++ b/Google.PowerShell/Dns/GcdChange.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Dns.v1;
 using Google.Apis.Dns.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Dns/GcdChange.cs
+++ b/Google.PowerShell/Dns/GcdChange.cs
@@ -131,7 +131,11 @@ namespace Google.PowerShell.Dns
     ///     <code>
     ///     PS C:\> $newARecord = New-GcdResourceRecordSet -Name "gcloudexample1.com." -Rrdata "104.1.34.167"
     ///     </code>
+    ///   </para>
+    ///   <para>
     ///     <code> PS C:\> $oldCNAMERecord = (Get-GcdResourceRecordSet -Zone "test1" -Filter "CNAME")[0]</code>
+    ///   </para>
+    ///   <para>
     ///     <code>
     ///     PS C:\> Add-GcdChange -Project "testing" -Zone "test1" -Add $newARecord -Remove $oldCNAMERecord
     ///     </code>
@@ -152,6 +156,8 @@ namespace Google.PowerShell.Dns
     ///   </para>
     ///   <para>
     ///     <code>PS C:\> $change2 = Get-GcdChange -Project "testing" -Zone "test1" -ChangeId 2 </code>
+    ///   </para>
+    ///   <para>
     ///     <code>PS C:\> Add-GcdChange -Project "testing" -Zone "test1" -ChangeRequest $change2</code>
     ///   </para>
     ///   <br></br>

--- a/Google.PowerShell/Dns/GcdCmdlet.cs
+++ b/Google.PowerShell/Dns/GcdCmdlet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Dns.v1;
 using Google.PowerShell.Common;
 

--- a/Google.PowerShell/Dns/GcdCmdlet.cs
+++ b/Google.PowerShell/Dns/GcdCmdlet.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Dns.v1;

--- a/Google.PowerShell/Dns/GcdManagedZone.cs
+++ b/Google.PowerShell/Dns/GcdManagedZone.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Dns.v1;
@@ -213,9 +215,9 @@ namespace Google.PowerShell.Dns
             }
 
             zoneContent.Description = Description ?? "";
-      
 
-            ManagedZonesResource.CreateRequest zoneCreateRequest = 
+
+            ManagedZonesResource.CreateRequest zoneCreateRequest =
                 Service.ManagedZones.Create(zoneContent, Project);
             ManagedZone newZone = zoneCreateRequest.Execute();
             WriteObject(newZone);

--- a/Google.PowerShell/Dns/GcdManagedZone.cs
+++ b/Google.PowerShell/Dns/GcdManagedZone.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Dns.v1;
 using Google.Apis.Dns.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Dns/GcdQuota.cs
+++ b/Google.PowerShell/Dns/GcdQuota.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Dns.v1;

--- a/Google.PowerShell/Dns/GcdQuota.cs
+++ b/Google.PowerShell/Dns/GcdQuota.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Dns.v1;
 using Google.Apis.Dns.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Dns/GcdResourceRecordSet.cs
+++ b/Google.PowerShell/Dns/GcdResourceRecordSet.cs
@@ -102,6 +102,7 @@ namespace Google.PowerShell.Dns
         /// </para>
         /// </summary>
         [Parameter(Position = 1, Mandatory = false)]
+        [ValidateSet("A", "AAAA", "CNAME", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF", "SRV", "TXT")]
         public string[] Filter { get; set; }
 
         protected override void ProcessRecord()

--- a/Google.PowerShell/Dns/GcdResourceRecordSet.cs
+++ b/Google.PowerShell/Dns/GcdResourceRecordSet.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2016 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Dns.v1;
@@ -106,7 +108,7 @@ namespace Google.PowerShell.Dns
         {
             base.ProcessRecord();
 
-            ResourceRecordSetsResource.ListRequest rrsetListRequest = 
+            ResourceRecordSetsResource.ListRequest rrsetListRequest =
                 Service.ResourceRecordSets.List(Project, Zone);
             ResourceRecordSetsListResponse rrsetListResponse = rrsetListRequest.Execute();
             IList<ResourceRecordSet> rrsetList = rrsetListResponse.Rrsets;

--- a/Google.PowerShell/Dns/GcdResourceRecordSet.cs
+++ b/Google.PowerShell/Dns/GcdResourceRecordSet.cs
@@ -71,6 +71,9 @@ namespace Google.PowerShell.Dns
     ///   <para>Type    : AAAA</para>
     ///   <para>ETag    :</para>
     /// </example>
+    /// <para type="link" uri="(https://cloud.google.com/dns/records/json-record)">
+    /// [Supported Resource Record Formats]
+    /// </para>
     /// <para type="link" uri="(https://cloud.google.com/dns/records/)">[Managing Records]</para>
     /// <para type="link" uri="(https://cloud.google.com/dns/troubleshooting)">[Troubleshooting]</para>
     /// </summary>
@@ -163,6 +166,9 @@ namespace Google.PowerShell.Dns
     ///   <para>Type    : A</para>
     ///   <para>ETag    :</para>
     /// </example>
+    /// <para type="link" uri="(https://cloud.google.com/dns/records/json-record)">
+    /// [Supported Resource Record Formats]
+    /// </para>
     /// <para type="link" uri="(https://cloud.google.com/dns/records/)">[Managing Records]</para>
     /// <para type="link" uri="(https://cloud.google.com/dns/troubleshooting)">[Troubleshooting]</para>
     /// </summary>

--- a/Google.PowerShell/Dns/GcdResourceRecordSet.cs
+++ b/Google.PowerShell/Dns/GcdResourceRecordSet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Dns.v1;
 using Google.Apis.Dns.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Properties/AssemblyInfo.cs
+++ b/Google.PowerShell/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System.Reflection;

--- a/Google.PowerShell/Properties/AssemblyInfo.cs
+++ b/Google.PowerShell/Properties/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/Google.PowerShell/Storage/GcsBucket.cs
+++ b/Google.PowerShell/Storage/GcsBucket.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Storage.v1;
 using Google.Apis.Storage.v1.Data;
 using Google.PowerShell.Common;

--- a/Google.PowerShell/Storage/GcsBucket.cs
+++ b/Google.PowerShell/Storage/GcsBucket.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Storage.v1;
@@ -150,7 +152,7 @@ namespace Google.PowerShell.CloudStorage
         /// </para>
         /// </summary>
         [Parameter]
-        public BucketsResource.InsertRequest.PredefinedAclEnum? DefaultBucketAcl {get; set;}
+        public BucketsResource.InsertRequest.PredefinedAclEnum? DefaultBucketAcl { get; set; }
 
         /// <summary>
         /// <para type="description">
@@ -204,7 +206,7 @@ namespace Google.PowerShell.CloudStorage
         /// <summary>
         /// Used for generating activity ids used by WriteProgress.
         /// </summary>
-        private static readonly Random ActivityIdGenerator = new Random();
+        private static readonly Random s_activityIdGenerator = new Random();
 
         /// <summary>
         /// <para typedef="description">
@@ -290,7 +292,7 @@ namespace Google.PowerShell.CloudStorage
         {
             int totalTasks = deleteTasks.Count;
             int finishedTasks = 0;
-            int activityId = ActivityIdGenerator.Next();
+            int activityId = s_activityIdGenerator.Next();
 
             foreach (var deleteTask in deleteTasks)
             {

--- a/Google.PowerShell/Storage/GcsBucketLogging.cs
+++ b/Google.PowerShell/Storage/GcsBucketLogging.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System.Management.Automation;

--- a/Google.PowerShell/Storage/GcsBucketLogging.cs
+++ b/Google.PowerShell/Storage/GcsBucketLogging.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System.Management.Automation;
 
 using Google.Apis.Auth.OAuth2;

--- a/Google.PowerShell/Storage/GcsBucketWebsite.cs
+++ b/Google.PowerShell/Storage/GcsBucketWebsite.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using System.Management.Automation;

--- a/Google.PowerShell/Storage/GcsBucketWebsite.cs
+++ b/Google.PowerShell/Storage/GcsBucketWebsite.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using System.Management.Automation;
 
 using Google.Apis.Auth.OAuth2;

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Storage.v1;

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Storage.v1;
 using Google.PowerShell.Common;
 using System;

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-// Licensed under the Apache License Version 2.0.
-
 using Google.Apis.Download;
 using Google.Apis.Storage.v1;
 using Google.Apis.Storage.v1.Data;

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Google Inc. All Rights Reserved.
+﻿// Copyright 2015-2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
 // Licensed under the Apache License Version 2.0.
 
 using Google.Apis.Download;

--- a/website/content/home.html
+++ b/website/content/home.html
@@ -82,6 +82,9 @@
         <a ng-click="selected = 'compute engine'"
            ng-class="{selected: selected == 'compute engine'}"
            >Compute Engine</a>
+        <a ng-click="selected = 'dns'"
+            ng-class="{selected: selected == 'dns'}"
+           >DNS</a>
       </div>
 
       <div hljs hljs-language="powershell" ng-show="selected == 'cloud storage'">
@@ -103,6 +106,15 @@ $config = New-GceInstanceConfig $vmName `
 $config | Add-GceInstance -Project $project -Zone "us-central1-b"
 
 $instance = Get-GceInstance $vmName
+      </div>
+
+      <div hljs hljs-language="powershell" ng-show="selected == 'dns'">
+Add-GcdManagedZone `
+    -Name "my-new-zone" `
+    -DnsName "dnsexample.com." `
+    -Description "This is my first zone."
+
+$newZone = Get-GcdManagedZone -Zone "my-new-zone"
       </div>
 
     </div>


### PR DESCRIPTION
- Ran "RunCodeFormatter.ps1"
- Add-GcdChange: Fleshed out some examples. 
- New/Get-GcdResourceRecordSet: Add links to page on supported resource record formats in Cloud DNS. 
- Added code sample to website for Cloud DNS. 
- Get-GcdResourceRecordSet: Added a ValidateSet restriction to Filter so that only supported ResourceRecordSet types can be specified. 