### PR TITLE
Update Google.Apis.Dns.v1 to version 1.15

### DIFF
--- a/Google.PowerShell/Google.PowerShell.csproj
+++ b/Google.PowerShell/Google.PowerShell.csproj
@@ -60,8 +60,8 @@
       <HintPath>..\packages\Google.Apis.Core.1.15.0\lib\net45\Google.Apis.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Dns.v1, Version=1.13.1.517, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Dns.v1.1.13.1.517\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Dns.v1.dll</HintPath>
+    <Reference Include="Google.Apis.Dns.v1, Version=1.15.0.517, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Dns.v1.1.15.0.517\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.Dns.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis.PlatformServices, Version=1.15.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">

--- a/Google.PowerShell/packages.config
+++ b/Google.PowerShell/packages.config
@@ -5,7 +5,7 @@
   <package id="Google.Apis.Auth" version="1.15.0" targetFramework="net452" />
   <package id="Google.Apis.Compute.v1" version="1.15.0.572" targetFramework="net452" />
   <package id="Google.Apis.Core" version="1.15.0" targetFramework="net452" />
-  <package id="Google.Apis.Dns.v1" version="1.13.1.517" targetFramework="net452" />
+  <package id="Google.Apis.Dns.v1" version="1.15.0.517" targetFramework="net452" />
   <package id="Google.Apis.SQLAdmin.v1beta4" version="1.13.1.494" targetFramework="net452" />
   <package id="Google.Apis.Storage.v1" version="1.15.0.573" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net452" />


### PR DESCRIPTION
Update Google.Apis.Dns.v1 to version 1.15 for consistency with other packages. Will throw errors when running Dns cmdlets otherwise.