### PR TITLE
Add Google Cloud DNS to products.json

### DIFF
--- a/website/_data/products.json
+++ b/website/_data/products.json
@@ -14,4 +14,9 @@
         "description": "Google Cloud SQL lets you set-up, maintain, manage, and administer your relational MySQL databases on Google's Cloud Platform.",
         "homepageUrl": "https://cloud.google.com/sql/"
     }
+    {
+        "productName":  "Google Cloud DNS",
+        "description": "Google Cloud DNS publishes your domain names on Google's global network of anycast name servers and lets you manage and administer them on Google's Cloud Platform.",
+        "homepageUrl": "https://cloud.google.com/dns/"
+    }
 ]

--- a/website/content/home.html
+++ b/website/content/home.html
@@ -59,13 +59,13 @@
     <div class="quote-box">
       <h3 class="block-title">What is it?</h3>
 
-      <p><code>Cloud Tools for PowerShell</code> is a set of PowerShell
+      <p><strong>Cloud Tools for PowerShell</strong> is a set of PowerShell
       cmdlets for accessing and manipulating Google Cloud Platform
       resources. With them you will be able to automate tasks by writing
       programs in PowerShell. And ultimately get more done on the
       Google Cloud Platform.</p>
 
-      <p><code>Cloud Tools for PowerShell</code> uses the same configuration
+      <p>Cloud Tools for PowerShell uses the same configuration
       and credentials used by the Google Cloud SDK (<code>gcloud</code>).
       Once you authenticate (<code>gcloud auth login</code>) you will be
       able to use PowerShell cmdlets.</p>
@@ -149,14 +149,14 @@ $newZone = Get-GcdManagedZone -Zone "my-new-zone"
     <div class="container clearfix">
     <h3 class="block-title">FAQ</h3>
 
-    <h4>What is the relationship between the <code>Cloud Tools for PowerShell</code>
+    <h4>What is the relationship between the Cloud Tools for PowerShell
     and the <code>gcloud</code> command-line tool?</h4>
 
-    <p>Both the <code>gcloud</code> command-line tool and <code>Cloud Tools for PowerShell</code>
+    <p>Both the <code>gcloud</code> command-line tool and Cloud Tools for PowerShell
     cmdlets allow you to manage your cloud resources. However, the
-    <code>Cloud Tools for PowerShell</code> returns strongly-typed objects rather than
-    plain text. So cmdlet results can be latter transformed within Windows PowerShell.
-    With <code>Cloud Tools for PowerShell</code> you can benefit from things like tab-completion,
+    Cloud Tools for PowerShell cmdlets return strongly-typed objects rather than
+    plain text, so that results can be more easily manipulated within Windows PowerShell.
+    With Cloud Tools for PowerShell you can benefit from things like tab-completion,
     type checking, and integrated help.</p>
     </div>
 </section> <!-- end of FAQ -->


### PR DESCRIPTION
This is needed for it to appear in the left navbar of the Reference tab. I work as part of this team at Google (alexdupuy@).

The Cloud DNS cmdlets page https://googlecloudplatform.github.io/google-cloud-powershell/cmdlets/google-cloud-dns.html gets a 404, it seems like the dns-cmdlets branch wasn't merged?
