### PR TITLE
Add missing Google Cloud DNS to products.json & home.html

### DIFF
--- a/website/_data/products.json
+++ b/website/_data/products.json
@@ -13,5 +13,10 @@
         "productName":  "Google Cloud SQL",
         "description": "Google Cloud SQL lets you set-up, maintain, manage, and administer your relational MySQL databases on Google's Cloud Platform.",
         "homepageUrl": "https://cloud.google.com/sql/"
+    },
+    {
+        "productName":  "Google Cloud DNS",
+        "description": "Google Cloud DNS publishes your domain names on Google's global network of anycast name servers and lets you manage and administer them on Google's Cloud Platform.",
+        "homepageUrl": "https://cloud.google.com/dns/"
     }
 ]

--- a/website/content/home.html
+++ b/website/content/home.html
@@ -141,6 +141,11 @@ $newZone = Get-GcdManagedZone -Zone "my-new-zone"
           Google Cloud SQL
         </a>
       </li>
+      <li>
+        <a href="{{baseUrl}}cmdlets/#google-cloud-dns">
+          Google Cloud DNS
+        </a>
+      </li>
     </ul>
   </div>
 </section>


### PR DESCRIPTION
I work as part of this team at Google (alexdupuy@).

This is needed for it to appear in the left navbar of the Reference tab, and with a link to the Cmdlet examples in the website.

There are other problems that this doesn't fix, in particular, the Cloud DNS cmdlets page https://googlecloudplatform.github.io/google-cloud-powershell/cmdlets/google-cloud-dns.html gets a 404, although the dns-cmdlets branch was merged. I don't see the file(s) in the latest merge to website from master PR#275 either, so that also needs to be regenerated with the Cloud DNS docs (probably after merging PR#274) but other action may be needed.