### PR TITLE
Add Cloud DNS to GenerateWebsiteData.ps1

### DIFF
--- a/Tools/GenerateWebsiteData.ps1
+++ b/Tools/GenerateWebsiteData.ps1
@@ -13,6 +13,7 @@ $apiMappings = @{
     "Gcs" = "Google Cloud Storage"
     "Gce" = "Google Compute Engine"
     "GcSql" = "Google Cloud SQL"
+    "Gcd" = "Google Cloud DNS"
 }
 
 # Generate a single JSON file containing all the documentation for all the


### PR DESCRIPTION
Add Cloud DNS to GenerateWebsiteData.ps1 to add it to http://googlecloudplatform.github.io/google-cloud-powershell/cmdlets/.