### PR TITLE
Add ability to upload folder to New-GCSObject

### DIFF
--- a/Google.PowerShell.IntegrationTests/Storage/Storage.GcsBucket.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Storage/Storage.GcsBucket.Tests.ps1
@@ -28,7 +28,7 @@ Describe "Get-GcsBucket" {
     }
 
     It "should list all buckets in a project" {
-        $buckets = Get-GcsBucket -Project $projec
+        $buckets = Get-GcsBucket -Project $project
         $buckets | Should Not BeNullOrEmpty
         ($buckets | Get-Member).TypeName | Should Be Google.Apis.Storage.v1.Data.Bucket
     }

--- a/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
@@ -246,7 +246,7 @@ Describe "New-GcsObject" {
         }
     }
 
-    It "should upload a folder with slashes at the end of the path" {
+    It "should work for both forwards slashes and backslashes in the path" {
         $folderName = [System.IO.Path]::GetRandomFileName()
         $testFolder = "$env:TEMP/$folderName"
 
@@ -254,7 +254,7 @@ Describe "New-GcsObject" {
             New-Item -ItemType Directory -Path $testFolder | Out-Null
             "Hello, world" | Out-File "$testFolder/world.txt"
 
-            # Add a backwards slash to the end and make sure it is uploaded.
+            # Add a backslash to the end and make sure it is uploaded.
             $result = New-GcsObject -Bucket $bucket -Folder "$testFolder\" -Force
 
             $result.Count | Should Be 2

--- a/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
@@ -222,12 +222,12 @@ Describe "New-GcsObject" {
 
             $folder = New-GcsObject -Bucket $bucket -Folder $testFolder -Force
 
-            $folder.Name | should be "$folderName/"
-            $folder.Size | should be 0
+            $folder.Name | Should Be "$folderName/"
+            $folder.Size | Should Be 0
 
             $folderOnline = Get-GcsObject -Bucket $bucket -ObjectName "$folderName/"
-            $folderOnline.Name | should be "$folderName/"
-            $folderOnline.Size | should be 0
+            $folderOnline.Name | Should Be "$folderName/"
+            $folderOnline.Size | Should Be 0
         }
         finally
         {
@@ -254,20 +254,36 @@ Describe "New-GcsObject" {
 
             $result = New-GcsObject -Bucket $bucket -Folder $testFolder -Force
 
-            $result.Count | should be 7
-            $result.Name -contains "$folderName/jupiter.txt" | should be $true
-            $result.Name -contains "$folderName/mars.txt" | should be $true
-            $result.Name -contains "$folderName/TestSubfolder/pluto.txt" | should be $true
+            # The query returns 7 even though we create 5 because 2 of them are folders.
+            $result.Count | Should Be 7
+            # Confirm the files and folders were created.
+            $result.Name -contains "$folderName/" | should be $true
+            $result.Name -contains "$folderName/world.txt" | Should Be $true
+            $result.Name -contains "$folderName/jupiter.txt" | Should Be $true
+            $result.Name -contains "$folderName/mars.txt" | Should Be $true
+            $result.Name -contains "$folderName/TestSubFolder/" | should be $true
+            $result.Name -contains "$folderName/TestSubfolder/pluto.txt" | Should Be $true
+            $result.Name -contains "$folderName/TestSubfolder/saturn.txt" | Should Be $true
 
             $saturn = Get-GcsObject -Bucket $bucket -ObjectName "$folderName/TestSubfolder/saturn.txt"
-            $saturn.ContentType | should be "text/plain"
+            $saturn.ContentType | Should Be "text/plain"
 
-            $objs = Find-GcsObject -Delimiter "/" -Bucket $bucket -Prefix "$folderName/TestSubfolder"
-            $objs.Count | should be 0
+            # This should contain everything except the TestSubFolder and its files.
+            $objs = Find-GcsObject -Delimiter "/" -Bucket $bucket -Prefix "$folderName/"
+            $objs.Count | Should Be 4
+            $objs.Name -contains "$folderName/TestSubfolder/pluto.txt" | Should Be $false
+            $objs.Name -contains "$folderName/TestSubfolder/saturn.txt" | Should Be $false
+            $objs.Name -contains "$folderName/TestSubfolder/" | Should Be $false
 
-            $objs = Find-GcsObject -Bucket $bucket -Prefix "$folderName/TestSubfolder"
-            $objs.Count | should be 3
-            $objs.Name -contains "$folderName/TestSubfolder/pluto.txt" | should be $true
+            # Everything should be returned!
+            $objs = Find-GcsObject -Bucket $bucket -Prefix "$folderName/"
+            $objs.Count | Should Be 7
+
+            $objs = Find-GcsObject -Bucket $bucket -Prefix "$folderName/TestSubfolder/"
+            $objs.Count | Should Be 3
+            $objs.Name -contains "$folderName/TestSubfolder/pluto.txt" | Should Be $true
+            $objs.Name -contains "$folderName/TestSubfolder/saturn.txt" | Should Be $true
+            $objs.Name -contains "$folderName/TestSubfolder/" | Should Be $true
         }
         finally
         {

--- a/Google.PowerShell/Common/GcloudCmdlet.cs
+++ b/Google.PowerShell/Common/GcloudCmdlet.cs
@@ -96,7 +96,7 @@ namespace Google.PowerShell.Common
 
                 // Only return the resolved path if there are no ambiguities.
                 // If path contains wildcards, then it may resolved to more than 1 path.
-                if (result.Length == 1 && provider.ImplementingType == typeof(FileSystemProvider))
+                if (result?.Length == 1 && provider.ImplementingType == typeof(FileSystemProvider))
                 {
                     return result[0];
                 }

--- a/Google.PowerShell/Common/GcloudCmdlet.cs
+++ b/Google.PowerShell/Common/GcloudCmdlet.cs
@@ -91,27 +91,28 @@ namespace Google.PowerShell.Common
             ProviderInfo provider = null;
             string[] result;
 
-            // resolve filepath and get the first one
+            // Resolve filepath.
             try
             {
                 result = GetResolvedProviderPathFromPSPath(filePath, out provider).ToArray();
             }
             catch (ItemNotFoundException itemEx)
             {
-                // in case the file path is not created but we should still return the resolve path
+                // In case the file path is not created, an error will be thrown.
+                // But we should still return the resolved path.
                 result = new string[] { itemEx.ItemName };
             }
 
             if (result.Length != 1)
             {
-                // cannot really resolve this
-                return null;
+                // Cannot really resolve this, just return the unresolved path.
+                return filePath;
             }
 
-            // otherwise, we also have to check that the provider is a filesystem
+            // Otherwise, we also have to check that the provider is a filesystem.
             if (provider.ImplementingType != typeof(FileSystemProvider))
             {
-                return null;
+                return filePath;
             }
 
             return result[0];

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -257,7 +257,7 @@ namespace Google.PowerShell.CloudStorage
             {
                 // User gives us the path to a folder, we will resolve the path and upload the contents of that folder.
                 // Have to take care of / and \ in the end of the directory path because Path.GetFileName will return
-                // empty string if that is not trimmed off.
+                // an empty string if that is not trimmed off.
                 string resolvedFolderPath = GetFullPath(Folder).TrimEnd("/\\".ToCharArray());
                 if (string.IsNullOrWhiteSpace(resolvedFolderPath) || !Directory.Exists(resolvedFolderPath))
                 {
@@ -269,6 +269,7 @@ namespace Google.PowerShell.CloudStorage
                 {
                     gcsObjectNamePrefix = Path.Combine(ObjectNamePrefix, gcsObjectNamePrefix);
                 }
+                // TODO(quoct): Add a progress indicator if there are too many files.
                 UploadDirectory(resolvedFolderPath, metadataDict, ConvertLocalToGcsFolderPath(gcsObjectNamePrefix));
                 return;
             }


### PR DESCRIPTION
Add -Folder parameter to New-GCSObject cmdlet to allow uploading of folder;
Use Cmdlet.GetResolvedProviderPathFromPSPath to resolve relative paths;
Instead of using -Path to combine File and Folder, I decided to add -Folder since there are certain parameters that can be applied to -File but not -Folder (like -ObjectName and -ContentType) and so it makes more sense to separate them into 2 different parameter sets.