### PR TITLE
Fix a bug where -RemoveDisk in Set-GceInstance cmdlet does not work with Disk object

### DIFF
--- a/Google.PowerShell.IntegrationTests/Compute/Compute.GceFirewall.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Compute/Compute.GceFirewall.Tests.ps1
@@ -74,11 +74,11 @@ Describe "Add-GceFirewall" {
 
     It "should work" {
         $firewall = Add-GceFirewall -Project $project $name -Allowed $allowed -Description "test Add $r" `
-            -SourceRange "192.168.100.0/22", "2001:db8::/48" -SourceTag "alpha" -TargetTag "beta"
+            -SourceRange "192.168.100.0/22", "192.168.100.0/30" -SourceTag "alpha" -TargetTag "beta"
         $firewall.Description | Should Be "test Add $r"
         $firewall.SourceRanges.Count | Should Be 2
         $firewall.SourceRanges -contains "192.168.100.0/22" | Should Be $true
-        $firewall.SourceRanges -contains "2001:db8::/48" | Should Be $true
+        $firewall.SourceRanges -contains "192.168.100.0/30" | Should Be $true
         $firewall.SourceTags | Should Be "alpha"
         $firewall.TargetTags | Should Be "beta"
     }

--- a/Google.PowerShell/Compute/GceInstanceCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceCmdlets.cs
@@ -1231,7 +1231,6 @@ namespace Google.PowerShell.ComputeEngine
             // The disks on the GCE instance we need to set.
             // This is used for the case when there are selflinks instead of disk names.
             IList<AttachedDisk> attachedDisks = null;
-            // Only selflink contain :// because those are not valid disk names.
             if (RemoveDisk != null && RemoveDisk.Any(diskName => Uri.IsWellFormedUriString(diskName, UriKind.Absolute)))
             {
                 Instance gceInstance = Service.Instances.Get(_project, _zone, _name).Execute();

--- a/Google.PowerShell/Compute/GceInstanceCmdlets.cs
+++ b/Google.PowerShell/Compute/GceInstanceCmdlets.cs
@@ -1098,6 +1098,7 @@ namespace Google.PowerShell.ComputeEngine
         /// </summary>
         [Parameter(ParameterSetName = ParameterSetNames.Disk)]
         [Parameter(ParameterSetName = ParameterSetNames.DiskByObject)]
+        [ValidateNotNullOrEmpty]
         public object[] AddDisk { get; set; } = { };
 
         /// <summary>
@@ -1107,7 +1108,8 @@ namespace Google.PowerShell.ComputeEngine
         /// </summary>
         [Parameter(ParameterSetName = ParameterSetNames.Disk)]
         [Parameter(ParameterSetName = ParameterSetNames.DiskByObject)]
-        [ArrayPropertyTransform(typeof(Disk), nameof(Disk.Name))]
+        [ArrayPropertyTransform(typeof(Disk), nameof(Disk.SelfLink))]
+        [ValidateNotNullOrEmpty]
         public string[] RemoveDisk { get; set; } = { };
 
         /// <summary>
@@ -1226,10 +1228,33 @@ namespace Google.PowerShell.ComputeEngine
         /// </summary>
         private void ProcessDisk()
         {
+            // The disks on the GCE instance we need to set.
+            // This is used for the case when there are selflinks instead of disk names.
+            IList<AttachedDisk> attachedDisks = null;
+            // Only selflink contain :// because those are not valid disk names.
+            if (RemoveDisk != null && RemoveDisk.Any(diskName => Uri.IsWellFormedUriString(diskName, UriKind.Absolute)))
+            {
+                Instance gceInstance = Service.Instances.Get(_project, _zone, _name).Execute();
+                attachedDisks = gceInstance?.Disks;
+            }
+
             foreach (string diskName in RemoveDisk)
             {
+                string detachedDiskName = diskName;
+                // If the diskName is a self link, we have to get the device name from attachedDisks list.
+                if (Uri.IsWellFormedUriString(diskName, UriKind.Absolute))
+                {
+                    AttachedDisk attachedDisk = attachedDisks.FirstOrDefault(
+                        disk => string.Equals(disk.Source, diskName, StringComparison.OrdinalIgnoreCase));
+                    if (attachedDisk == null)
+                    {
+                        WriteResourceMissingError($"Disk '{diskName}' cannot be found.", "MissingAttachedDisk", diskName);
+                        continue;
+                    }
+                    detachedDiskName = attachedDisk.DeviceName;
+                }
                 InstancesResource.DetachDiskRequest request = Service.Instances.DetachDisk(
-                    _project, _zone, _name, diskName);
+                    _project, _zone, _name, detachedDiskName);
                 Operation operation = request.Execute();
                 AddZoneOperation(_project, _zone, operation, () =>
                 {


### PR DESCRIPTION
This is because we are using the Name property from the Disk object. However, this property gives us the persistent name of the Disk whereas what we need is the DeviceName of the disk (what the VM sees the Disk as).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/411)
<!-- Reviewable:end -->
