### PR TITLE
Add the ability to download gcloud SDK

### DIFF
--- a/Google.PowerShell/ReleaseFiles/GoogleCloud.psd1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloud.psd1
@@ -9,7 +9,7 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-RootModule = 'Google.PowerShell.dll'
+RootModule = 'GoogleCloudPowerShell.psm1'
 
 # Version number of this module.
 ModuleVersion = '1.0.0.3'

--- a/Google.PowerShell/ReleaseFiles/GoogleCloudPowerShell.psd1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloudPowerShell.psd1
@@ -13,7 +13,7 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-RootModule = '..\PowerShell\GoogleCloud\Google.PowerShell.dll'
+RootModule = '..\PowerShell\GoogleCloud\GoogleCloudPowerShell.psm1'
 
 # Version number of this module.
 ModuleVersion = '0.1.10.0'

--- a/Google.PowerShell/ReleaseFiles/GoogleCloudPowerShell.psm1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloudPowerShell.psm1
@@ -63,4 +63,5 @@ function Install-GCloudSdk {
     }
 }
 
+Install-GCloudSdk
 Import-Module "$script:GCloudModulePath\Google.PowerShell.dll"

--- a/Google.PowerShell/ReleaseFiles/GoogleCloudPowerShell.psm1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloudPowerShell.psm1
@@ -1,21 +1,27 @@
 ﻿$script:GCloudModule = $ExecutionContext.SessionState.Module
 $script:GCloudModulePath = $script:GCloudModule.ModuleBase
 
-$gCloudSDK = Get-Command gcloud -ErrorAction SilentlyContinue
-
-# Install Google Cloud SDK. To install it non-interactively, use -Force.
+# Check and install Google Cloud SDK if it is not present. To install it non-interactively,
+# set GCLOUD_SDK_INSTALLATION_NO_PROMPT to $true.
 function Install-GCloudSdk {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    Param(
-        [switch]$force
-    )
+    Param()
+
+    $gCloudSDK = Get-Command gcloud -ErrorAction SilentlyContinue
+
+    if ($null -ne $gCloudSDK) {
+        return
+    }
+
+    Write-Host "Google Cloud SDK is not found in PATH. The SDK is required to run the module."
+    $noPrompt = $env:GCLOUD_SDK_INSTALLATION_NO_PROMPT -eq $true
 
     $query = "Do you want to install Google Cloud SDK? If you want to force the installation without prompt," +
              " set `$env:GCLOUD_SDK_INSTALLATION_NO_PROMPT to true."
     $caption = "Installing Google Cloud SDK"
 
     if ($PSCmdlet.ShouldProcess("Google Cloud SDK", "Install")) {
-        if ($Force) {
+        if ($noPrompt) {
             # We use this method of installation instead of the installer because the installer does all the installation
             # in the background so we can't determine when it's done.
             $cloudSdkUri = "https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip"
@@ -55,12 +61,6 @@ function Install-GCloudSdk {
             }
         }
     }
-}
-
-if ($null -eq $gCloudSDK) {
-    Write-Host "Google Cloud SDK is not found in PATH. The SDK is required to run the module."
-    $prompt = $env:GCLOUD_SDK_INSTALLATION_NO_PROMPT -eq $true
-    Install-GCloudSdk -force:$prompt
 }
 
 Import-Module "$script:GCloudModulePath\Google.PowerShell.dll"

--- a/Google.PowerShell/ReleaseFiles/GoogleCloudPowerShell.psm1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloudPowerShell.psm1
@@ -1,0 +1,66 @@
+﻿$script:GCloudModule = $ExecutionContext.SessionState.Module
+$script:GCloudModulePath = $script:GCloudModule.ModuleBase
+
+$gCloudSDK = Get-Command gcloud -ErrorAction SilentlyContinue
+
+# Install Google Cloud SDK. To install it non-interactively, use -Force.
+function Install-GCloudSdk {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    Param(
+        [switch]$force
+    )
+
+    $query = "Do you want to install Google Cloud SDK? If you want to force the installation without prompt," +
+             " set `$env:GCLOUD_SDK_INSTALLATION_NO_PROMPT to true."
+    $caption = "Installing Google Cloud SDK"
+
+    if ($PSCmdlet.ShouldProcess("Google Cloud SDK", "Install")) {
+        if ($Force) {
+            # We use this method of installation instead of the installer because the installer does all the installation
+            # in the background so we can't determine when it's done.
+            $cloudSdkUri = "https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip"
+            $zipFileLocation = Join-Path $env:TMP ([System.IO.Path]::GetRandomFileName())
+            $extractedFolder = Join-Path $env:TMP ([System.IO.Path]::GetRandomFileName())
+            $installationPath = "$env:LOCALAPPDATA\Google\Cloud SDK"
+
+            Invoke-WebRequest -Uri $cloudSdkUri -OutFile $zipFileLocation
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+            # This will extract it to a folder $env:APPDATA\google-cloud-sdk.
+            Write-Host "Extracting Google Cloud SDK to '$extractedFolder' ..."
+            [System.IO.Compression.ZipFile]::ExtractToDirectory($zipFileLocation, $extractedFolder)
+
+            md $installationPath | Out-Null
+            Write-Host "Moving Google Cloud SDK to '$installationPath' ..."
+            Copy-Item "$extractedFolder\google-cloud-sdk" $installationPath -Recurse -Force
+
+            # Set this to true to disable prompts.
+            $env:CLOUDSDK_CORE_DISABLE_PROMPTS = $true
+            Write-Host "Running installation script ..."
+            & "$installationPath\google-cloud-sdk\install.bat" --quiet 2>$null
+
+            $cloudBinPath = "$installationPath\google-cloud-sdk\bin"
+            $envPath = [System.Environment]::GetEnvironmentVariable("Path")
+            if (-not $envPath.Contains($cloudBinPath)) {
+                [System.Environment]::SetEnvironmentVariable("Path", "$envPath;$cloudBinPath")
+            }
+        }
+        else {
+            if ($PSCmdlet.ShouldContinue($query, $caption)) {
+                $cloudSdkInstaller = "https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe"
+                $installerLocation = Join-Path $env:TMP "$([System.IO.Path]::GetRandomFileName()).exe"
+                Invoke-WebRequest -Uri $cloudSdkInstaller -OutFile $installerLocation
+                & $installerLocation
+                Write-Warning "You may have to restart the shell before gcloud can be used."
+            }
+        }
+    }
+}
+
+if ($null -eq $gCloudSDK) {
+    Write-Host "Google Cloud SDK is not found in PATH. The SDK is required to run the module."
+    $prompt = $env:GCLOUD_SDK_INSTALLATION_NO_PROMPT -eq $true
+    Install-GCloudSdk -force:$prompt
+}
+
+Import-Module "$script:GCloudModulePath\Google.PowerShell.dll"


### PR DESCRIPTION
If user has the module without the Cloud SDK installed, the module will proceed to install the SDK. This scenario is needed when we publish the module to the PowerShell Gallery without the SDK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/451)
<!-- Reviewable:end -->
