### PR TITLE
Fix formating for get-gceinstance

### DIFF
--- a/Google.PowerShell/ReleaseFiles/GoogleCloudPlatform.Format.ps1xml
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloudPlatform.Format.ps1xml
@@ -1,18 +1,45 @@
 ﻿<Configuration>
-  <SelectionSets>
-    <SelectionSet>
-      <Name>GoogleCloudStorageTypes</Name>
-      <Types>
-        <TypeName>Google.Apis.Storage.v1.Data.Bucket</TypeName>
-        <TypeName>Google.Apis.Storage.v1.Data.Object</TypeName>
-      </Types>
-    </SelectionSet>
-  </SelectionSets>
   <ViewDefinitions>
     <View>
-      <Name>Google Cloud Storage Table</Name>
+      <Name>Google Cloud Storage Bucket Table</Name>
       <ViewSelectedBy>
-        <SelectionSetName>GoogleCloudStorageTypes</SelectionSetName>
+        <TypeName>Google.Apis.Storage.v1.Data.Bucket</TypeName>
+      </ViewSelectedBy>
+      <GroupBy>
+        <Label>ParentPath</Label>
+        <ScriptBlock>
+          $_.PSParentPath.Replace("Google.PowerShell\GoogleCloudStorage::", "").Replace("\", "/")
+        </ScriptBlock>
+      </GroupBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Name</Label>
+          </TableColumnHeader>
+          <TableColumnHeader/>
+          <TableColumnHeader/>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <ScriptBlock>($_.PSChildName, $_.Name -ne $null)[0]</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>TimeCreated</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Updated</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
+      <Name>Google Cloud Storage Object Table</Name>
+      <ViewSelectedBy>
+        <TypeName>Google.Apis.Storage.v1.Data.Object</TypeName>
       </ViewSelectedBy>
       <GroupBy>
         <Label>ParentPath</Label>
@@ -47,6 +74,64 @@
               </TableColumnItem>
               <TableColumnItem>
                 <PropertyName>Updated</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
+      <Name>Google Compute Engine Instance</Name>
+      <ViewSelectedBy>
+        <TypeName>Google.Apis.Compute.v1.Data.Instance</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader/>
+          <TableColumnHeader/>
+          <TableColumnHeader>
+            <Label>MachineType</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Zone</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>TimeCreated</Label>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>CpuPlatform</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                    $reg = [Regex]"https:.*/zones/[^/]*/machineTypes/([^/]*)";
+                    $match = $reg.Match($_.MachineType);
+                    if ($match.Success) {
+                        $match.Groups[1].Value;
+                    } else {
+                        $_.MachineType;
+                    }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                    $reg = [Regex]"https:.*/zones/([^/]*)";
+                    $match = $reg.Match($_.Zone);
+                    if ($match.Success) {
+                        $match.Groups[1].Value;
+                    } else {
+                        $_.Zone;
+                    }
+                </ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.CreationTimestamp</ScriptBlock>
               </TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>

--- a/Google.PowerShell/ReleaseFiles/GoogleCloudPlatform.Format.ps1xml
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloudPlatform.Format.ps1xml
@@ -110,10 +110,8 @@
               </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>
-                    $reg = [Regex]"https:.*/zones/[^/]*/machineTypes/([^/]*)";
-                    $match = $reg.Match($_.MachineType);
-                    if ($match.Success) {
-                        $match.Groups[1].Value;
+                    if ($_.MachineType -match "https:.*/zones/[^/]*/machineTypes/([^/]*)") {
+                        $Matches[1]
                     } else {
                         $_.MachineType;
                     }
@@ -121,17 +119,15 @@
               </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>
-                    $reg = [Regex]"https:.*/zones/([^/]*)";
-                    $match = $reg.Match($_.Zone);
-                    if ($match.Success) {
-                        $match.Groups[1].Value;
+                    if ($_.Zone -match "https:.*/zones/([^/]*)") {
+                        $Matches[1]
                     } else {
                         $_.Zone;
                     }
                 </ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
-                <ScriptBlock>$_.CreationTimestamp</ScriptBlock>
+                <PropertyName>CreationTimestamp</PropertyName>
               </TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>


### PR DESCRIPTION
Also, separate the format for bucket and object (because bucket does not have ContentType and Size properties.
![image5](https://cloud.githubusercontent.com/assets/4371645/22752288/c91b9ae0-edec-11e6-8c55-0202e3fca088.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/452)
<!-- Reviewable:end -->
