### PR TITLE
Get-GcbqDataset fixes from past PR

### DIFF
--- a/Google.PowerShell.IntegrationTests/BigQuery/BigQuery.GcbqDataset.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/BigQuery/BigQuery.GcbqDataset.Tests.ps1
@@ -38,6 +38,30 @@ Describe "Get-GcbqDataset" {
         }
     }
 
+    It "should get using a pre-existing Dataset (to refresh data from the cloud)" {
+        try {
+            New-GcbqDataset "test_id_2"
+            $a = Get-GcbqDataset "test_id_2"
+            $b = $a | Get-GcbqDataset
+            $b.GetType() | Should Be "Google.Apis.Bigquery.v2.Data.Dataset"
+        }
+        finally {
+            Get-GcbqDataset "test_id_2" |  Remove-GcbqDataset
+        }
+    }
+
+    It "should get using a DatasetReference" {
+        try {
+            New-GcbqDataset "test_id_2"
+            $a = Get-GcbqDataset "test_id_2"
+            $b = $a.DatasetReference | Get-GcbqDataset
+            $b.GetType() | Should Be "Google.Apis.Bigquery.v2.Data.Dataset"
+        }
+        finally {
+            Get-GcbqDataset "test_id_2" |  Remove-GcbqDataset
+        }
+    }
+
     It "should handle when a dataset does not exist" {
         { Get-GcbqDataset "test_id_5" -ErrorAction Stop } | Should Throw 404
     }

--- a/Google.PowerShell/BigQuery/GcbqDataset.cs
+++ b/Google.PowerShell/BigQuery/GcbqDataset.cs
@@ -58,7 +58,8 @@ namespace Google.PowerShell.BigQuery
         private class ParameterSetNames
         {
             public const string List = "List";
-            public const string Get = "Get";
+            public const string GetWithString = "GetWithString";
+            public const string GetWithRef = "GetWithRef";
         }
 
         /// <summary>
@@ -95,12 +96,22 @@ namespace Google.PowerShell.BigQuery
         /// DatasetData objects so they can be mapped to full Dataset objects.
         /// </para>
         /// </summary>
-        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSetNames.Get)]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, 
+            ParameterSetName = ParameterSetNames.GetWithString)]
+        public string Dataset { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// INSERT TEXT HERE
+        /// </para>
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, 
+            ParameterSetName = ParameterSetNames.GetWithRef)]
         [PropertyByTypeTransformation(TypeToTransform = typeof(DatasetList.DatasetsData),
             Property = nameof(DatasetList.DatasetsData.DatasetReference))]
-        [PropertyByTypeTransformation(TypeToTransform = typeof(Dataset), Property = nameof(Apis.Bigquery.v2.Data.Dataset.DatasetReference))]
-        [PropertyByTypeTransformation(TypeToTransform = typeof(DatasetReference), Property = nameof(DatasetReference.DatasetId))]
-        public string Dataset { get; set; }
+        [PropertyByTypeTransformation(TypeToTransform = typeof(Dataset), 
+            Property = nameof(Apis.Bigquery.v2.Data.Dataset.DatasetReference))]
+        public DatasetReference DatasetRef { get; set; }
 
         protected override void ProcessRecord()
         {
@@ -110,11 +121,18 @@ namespace Google.PowerShell.BigQuery
                     var datasets = DoListRequest(Project);
                     WriteObject(datasets, true);
                     break;
-                case ParameterSetNames.Get:
+                case ParameterSetNames.GetWithString:
                     var dataset = DoGetRequest(Project, Dataset);
                     if (dataset != null)
                     {
                         WriteObject(dataset);
+                    }
+                    break;
+                case ParameterSetNames.GetWithRef:
+                    var datasetDR = DoGetRequest(DatasetRef.ProjectId, DatasetRef.DatasetId);
+                    if (datasetDR != null)
+                    {
+                        WriteObject(datasetDR);
                     }
                     break;
                 default:

--- a/Google.PowerShell/BigQuery/GcbqDataset.cs
+++ b/Google.PowerShell/BigQuery/GcbqDataset.cs
@@ -102,7 +102,7 @@ namespace Google.PowerShell.BigQuery
 
         /// <summary>
         /// <para type="description">
-        /// INSERT TEXT HERE
+        /// DatasetRefrence object used to pass in Project and Dataset values.
         /// </para>
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, 


### PR DESCRIPTION
@ILMTitan - Here's the promised other PR to focus in on that Database issue.  

Context from last PR:

Consider:
```
gcloud config set core/project your-project
$whatTables = Get-BqDataset -Project "my-project" | Get-BqTable
```
$whatTables will now contain Tables from "your-project" even though the command was piped in Datasets from "my-project". Users will find that very surprising. Instead, we need to have two parameter sets, one that takes a -Project [string] and a -DatasetId [string], and one that takes a -Dataset [DatasetReference], because DatasetReference has both project and datasetId