### PR TITLE
Add New-GkeNodeConfig cmdlet

### DIFF
--- a/Google.PowerShell.IntegrationTests/Compute2/Compute.GceServiceAccount.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Compute2/Compute.GceServiceAccount.Tests.ps1
@@ -21,6 +21,17 @@ Describe "New-GceServiceAccountConfig" {
         ($account.Scopes -match "devstorage.read_only").Count | Should Be 1
     }
 
+    It "should use default service account if -Email is not provided" {
+        $account = New-GceServiceAccountConfig
+        $account.Scopes.Count | Should Be 5
+        ($account.Scopes -match "logging.write").Count | Should Be 1
+        ($account.Scopes -match "monitoring.write").Count | Should Be 1
+        ($account.Scopes -match "servicecontrol").Count | Should Be 1
+        ($account.Scopes -match "service.management").Count | Should Be 1
+        ($account.Scopes -match "devstorage.read_only").Count | Should Be 1
+        $account.Email | Should Match "-compute@developer.gserviceaccount.com"
+    }
+
     It "should get none" {
         $account = New-GceServiceAccountConfig $email -Storage None -CloudLogging None -CloudMonitoring None `
             -ServiceControl $false -ServiceManagement $false

--- a/Google.PowerShell.IntegrationTests/Container/Container.GkeCluster.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Container/Container.GkeCluster.Tests.ps1
@@ -68,8 +68,99 @@ Describe "Get-GkeCluster" {
     }
 
     It "should raise an error for non-existing cluster" {
-        { Get-GkeCluster -ClusterName "cluster-no-exist-$r" -ErrorActionStop } |
+        { Get-GkeCluster -ClusterName "cluster-no-exist-$r" -ErrorAction Stop } |
             Should Throw "cannot be found"
+    }
+
+    AfterAll {
+        gcloud container clusters delete $clusterOneName -q 2>$null
+        gcloud container clusters delete $clusterTwoName -q 2>$null
+        gcloud container clusters delete $clusterThreeName -q 2>$null
+    }
+}
+
+Describe "New-GkeNodeConfig" {
+    It "should work with -ImageType" {
+        $nodeConfig = New-GkeNodeConfig -ImageType container_vm
+        $nodeConfig.ImageType | Should BeExactly container_vm
+    }
+
+    It "should work with -MachineType" {
+        $nodeConfig = New-GkeNodeConfig -ImageType container_vm -MachineType n1-standard-1
+        $nodeConfig.ImageType | Should BeExactly container_vm
+        $nodeConfig.MachineType | Should BeExactly n1-standard-1
+    }
+
+    It "should work with -DiskSizeGb" {
+        $nodeConfig = New-GkeNodeConfig -MachineType n1-highcpu-2 -DiskSizeGb 20
+        $nodeConfig.MachineType | Should BeExactly n1-highcpu-2
+        $nodeConfig.DiskSizeGb | Should Be 20
+    }
+
+    It "should work with -LocalSsdCount" {
+        $nodeConfig = New-GkeNodeConfig -ImageType gci -MachineType n1-highcpu-4 -LocalSsdCount 2
+        $nodeConfig.MachineType | Should BeExactly n1-highcpu-4
+        $nodeConfig.ImageType | Should BeExactly gci
+        $nodeConfig.LocalSsdCount | Should Be 2
+    }
+
+    It "should work with -Metadata" {
+        $nodeConfig = New-GkeNodeConfig -ImageType gci -Metadata @{"key" = "value"}
+        $nodeConfig.ImageType | Should BeExactly gci
+        $nodeConfig.Metadata["key"] | Should BeExactly "value"
+    }
+
+    It "should work with -Label" {
+        $nodeConfig = New-GkeNodeConfig -ImageType gci -Metadata @{"key" = "value"} -Label @{"release" = "stable"}
+        $nodeConfig.ImageType | Should BeExactly gci
+        $nodeConfig.Metadata["key"] | Should BeExactly "value"
+        $nodeConfig.Labels["release"] | Should BeExactly "stable"
+    }
+
+    It "should work with -Preemptible" {
+        $nodeConfig = New-GkeNodeConfig -LocalSsdCount 3 -Preemptible
+        $nodeConfig.Preemptible | Should Be $true
+        $nodeConfig.LocalSsdCount | Should Be 3
+    }
+
+    It "should work with default service account" {
+        $serviceAccount = New-GceServiceAccountConfig -BigtableAdmin Full `
+                                                      -CloudLogging None `
+                                                      -CloudMonitoring None `
+                                                      -ServiceControl $false `
+                                                      -ServiceManagement $false `
+                                                      -Storage None
+        $nodeConfig = New-GkeNodeConfig -ServiceAccount $serviceAccount
+        $nodeConfig.ServiceAccount | Should Match "-compute@developer.gserviceaccount.com"
+        $nodeConfig.OauthScopes | Should Match "bigtable.admin"
+    }
+
+    It "should work with a non-default service account" {
+        $serviceAccount = New-GceServiceAccountConfig -Email testing@gserviceaccount.com `
+                                                      -BigtableAdmin Full `
+                                                      -CloudLogging None `
+                                                      -CloudMonitoring None `
+                                                      -ServiceControl $false `
+                                                      -ServiceManagement $false `
+                                                      -Storage None
+        $nodeConfig = New-GkeNodeConfig -ServiceAccount $serviceAccount
+        $nodeConfig.ServiceAccount | Should Match "testing@gserviceaccount.com"
+        $nodeConfig.OauthScopes | Should Match "bigtable.admin"
+    }
+
+    It "should raise an error for bad metadata key" {
+        { New-GkeNodeConfig -Metadata @{"#$" = "value"} } |
+            Should Throw "can only be alphanumeric, hyphen or underscore."
+
+        { New-GkeNodeConfig -Metadata @{"instance-template" = "test" } } | Should Throw "reserved keyword"
+    }
+
+    It "should raise an error for negative SsdCount" {
+        { New-GkeNodeConfig -LocalSsdCount -3 } | Should Throw "less than the minimum allowed range of 0"
+    }
+
+    It "should raise an error for wrong DiskSize" {
+        { New-GkeNodeConfig -DiskSizeGb 3 } | Should Throw "less than the minimum allowed range of 10"
     }
 
     AfterAll {

--- a/Google.PowerShell/CloudResourceManager/IamPolicyCmdlets.cs
+++ b/Google.PowerShell/CloudResourceManager/IamPolicyCmdlets.cs
@@ -185,26 +185,8 @@ namespace Google.PowerShell.CloudResourceManager
                 };
                 List<Attribute> attributeLists = new List<Attribute>() { paramAttribute };
 
-                if (Project != null)
-                {
-                    // If the cmdlet is not executing and the user is only using tab completion, the string project
-                    // will have double quotes at the start and end so we have to trim that.
-                    Project = Project.Trim('"');
-
-                    // If the project is a variable, then we have to extract out the variable name.
-                    if (Project.StartsWith("$"))
-                    {
-                        // Try to resolve the variable project, if unsuccessful, set it to an empty string.
-                        Project = ResolveVariable(Project, string.Empty).ToString();
-                    }
-                }
-
-                // If we cannot resolve the variable or the user has not entered parameter for the project yet,
-                // project will be null here.
-                if (string.IsNullOrWhiteSpace(Project))
-                {
-                    Project = CloudSdkSettings.GetSettingsValue(CloudSdkSettings.CommonProperties.Project);
-                }
+                // Try to resolve Project variable to a string, use default value from the SDK if we fail to do so.
+                Project = GetCloudSdkSettingValue(CloudSdkSettings.CommonProperties.Project, Project);
 
                 string[] roles = GetGrantableRoles(Project);
                 // If there are no roles, do not add validate set attribute to the parameter (hence, no tab completion).

--- a/Google.PowerShell/Common/GcloudCmdlet.cs
+++ b/Google.PowerShell/Common/GcloudCmdlet.cs
@@ -28,6 +28,8 @@ namespace Google.PowerShell.Common
         private const string UnknownCmdletName = "unknown-cmdlet";
 
         // Resource Service used for getting project number.
+        protected CloudResourceManagerService ResourceService => _resourceService.Value;
+
         private Lazy<CloudResourceManagerService> _resourceService =
             new Lazy<CloudResourceManagerService>(() => new CloudResourceManagerService(GetBaseClientServiceInitializer()));
 
@@ -333,7 +335,7 @@ namespace Google.PowerShell.Common
         /// </summary>
         protected string GetProjectNumber(string projectId)
         {
-            ProjectsResource.GetRequest getRequest = _resourceService.Value.Projects.Get(Project);
+            ProjectsResource.GetRequest getRequest = ResourceService.Projects.Get(Project);
             Project project = getRequest.Execute();
             return project.ProjectNumber.ToString();
         }

--- a/Google.PowerShell/Common/GcloudCmdlet.cs
+++ b/Google.PowerShell/Common/GcloudCmdlet.cs
@@ -27,6 +27,10 @@ namespace Google.PowerShell.Common
         /// <summary>Placeholder for an unknown cmdlet name when reporting telemetry.</summary>
         private const string UnknownCmdletName = "unknown-cmdlet";
 
+        // Resource Service used for getting project number.
+        private Lazy<CloudResourceManagerService> _resourceService =
+            new Lazy<CloudResourceManagerService>(() => new CloudResourceManagerService(GetBaseClientServiceInitializer()));
+
         /// <summary>
         /// The project that is used by the cmdlet. This value will be used in reporting usage.
         /// The logic is in the Dispose function. We will map this project id to a project number.
@@ -292,6 +296,48 @@ namespace Google.PowerShell.Common
             return GetVariableValue(variable, defaultValue);
         }
 
+
+        /// <summary>
+        /// Given a settingName (e.g. Project) and a settingValue (e.g. "gcloud-testing" or $project),
+        /// this function will try to first resolve the settingValue to a string. If it fails to do so,
+        /// then the function will look into the Cloud SDK Settings to get the default value.
+        /// </summary>
+        protected string GetCloudSdkSettingValue(string settingName, string settingValue)
+        {
+            if (settingValue != null)
+            {
+                // If the cmdlet is not executing and the user is only using tab completion, the string parameterValue
+                // will have double quotes at the start and end so we have to trim that.
+                settingValue = settingValue.Trim('"');
+
+                // If the parameterValue is a variable, then we have to extract out the variable name.
+                if (settingValue.StartsWith("$"))
+                {
+                    // Try to resolve the variable parameterValue, if unsuccessful, set it to an empty string.
+                    settingValue = ResolveVariable(settingValue, string.Empty).ToString();
+                }
+            }
+
+            // If we cannot resolve the variable or the user has not entered parameter yet, parameterValue is null here.
+            // So we will get the value from Cloud SDK Settings.
+            if (string.IsNullOrWhiteSpace(settingValue))
+            {
+                settingValue = CloudSdkSettings.GetSettingsValue(settingName);
+            }
+
+            return settingValue;
+        }
+
+        /// <summary>
+        /// Returns a project number based on a project ID.
+        /// </summary>
+        protected string GetProjectNumber(string projectId)
+        {
+            ProjectsResource.GetRequest getRequest = _resourceService.Value.Projects.Get(Project);
+            Project project = getRequest.Execute();
+            return project.ProjectNumber.ToString();
+        }
+
         public void Dispose()
         {
             string cmdletName = GetCmdletName();
@@ -314,10 +360,7 @@ namespace Google.PowerShell.Common
                     Project = CloudSdkSettings.GetDefaultProject();
                 }
 
-                var resourceService = new CloudResourceManagerService(GetBaseClientServiceInitializer());
-                ProjectsResource.GetRequest getRequest = resourceService.Projects.Get(Project);
-                Project project = getRequest.Execute();
-                projectNumber = project.ProjectNumber.ToString();
+                projectNumber = GetProjectNumber(Project);
             }
             catch { }
 

--- a/Google.PowerShell/Compute/GceServiceAccountConfigCmdlets.cs
+++ b/Google.PowerShell/Compute/GceServiceAccountConfigCmdlets.cs
@@ -16,8 +16,7 @@ namespace Google.PowerShell.ComputeEngine
     /// Creates a new ServiceAccount object. These objects are used by New-GceInstanceConfig and 
     /// Add-GceInstanceTemplate cmdlets to link to service accounts and define scopes. These scopes in turn let
     /// your instances access Google Cloud Platform resources.
-    /// If no service account email is specified, the cmdlet will use the default service account email:
-    /// https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_default_service_account.
+    /// If no service account email is specified, the cmdlet will use the default service account email.
     /// </para>
     /// <example>
     ///   <code>
@@ -33,8 +32,12 @@ namespace Google.PowerShell.ComputeEngine
     ///   <para>
     ///   Creates a scope on the default service account that can make BigQuery queries and read bigtable data.
     ///   </para>
-    /// </example>/// <para type="link" uri="(https://cloud.google.com/compute/docs/reference/latest/instances#resource)">
+    /// </example>
+    /// <para type="link" uri="(https://cloud.google.com/compute/docs/reference/latest/instances#resource)">
     /// [Instance resource definition]
+    /// </para>
+    /// <para type="link" uri="(https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_default_service_account)">
+    /// [Default Service Account email]
     /// </para>
     /// </summary>
     [Cmdlet(VerbsCommon.New, "GceServiceAccountConfig", DefaultParameterSetName = ParameterSetNames.FromFlags)]

--- a/Google.PowerShell/Container/GkeClusterCmdlets.cs
+++ b/Google.PowerShell/Container/GkeClusterCmdlets.cs
@@ -170,12 +170,333 @@ namespace Google.PowerShell.Container
     }
 
     /// <summary>
+    /// Abstract class for cmdlets that deal with node configuration such as
+    /// New-GkeNodeConfig and Add-GkeCluster.
+    /// </summary>
+    public abstract class GkeNodeConfigCmdlet : GkeCmdlet, IDynamicParameters
+    {
+        // IAM Service used for getting roles that can be granted to a project.
+        private Lazy<ComputeService> _computeService =
+            new Lazy<ComputeService>(() => new ComputeService(GetBaseClientServiceInitializer()));
+
+        // Regex that is used to check metadata key.
+        private static readonly Regex s_metadataKeyRegex = new Regex("[a-zA-Z0-9-_]+");
+
+        // Reserved key word for metadata key.
+        private static readonly string[] s_reservedMetadataKey =
+            new string[] { "instance-template", "kube-env", "startup-script", "user-data" };
+
+        /// <summary>
+        /// <para type="description">
+        /// The project that the node config belongs to.
+        /// This parameter defaults to the project in the Cloud SDK config.
+        /// </para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        [ConfigPropertyName(CloudSdkSettings.CommonProperties.Project)]
+        public override string Project { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// The zone that the node config belongs to.
+        /// This parameter defaults to the project in the Cloud SDK config.
+        /// </para>
+        /// </summary>
+        [Parameter]
+        [ConfigPropertyName(CloudSdkSettings.CommonProperties.Zone)]
+        public virtual string Zone { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// Size of the disk attached to each node, specified in GB.
+        /// The smallest allowed disk size is 10GB.
+        /// The default disk size is 100GB.
+        /// </para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        [ValidateRange(10, int.MaxValue)]
+        public virtual int? DiskSizeGb { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// Metadata key/value pairs assigned to instances in the cluster.
+        /// Keys must conform to the regexp [a-zA-Z0-9-_]+ and not conflict with any other
+        /// metadata keys for the project or be one of the four reserved keys: "instance-template",
+        /// "kube-env", "startup-script" and "user-data".
+        /// </para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        [Alias("Metadata")]
+        public virtual Hashtable InstanceMetadata { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// The map of Kubernetes labels (key/value pairs) to be applied to each node.
+        /// This is in addition to any default label(s) that Kubernetes may apply to the node.
+        /// </para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public virtual Hashtable Label { get; set; }
+
+        /// <summary>
+        /// <para type="description">
+        /// The number of local SSD disks attached to each node.
+        /// </para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        [ValidateRange(0, int.MaxValue)]
+        public virtual int? LocalSsdCount { get; set; }
+
+        /// <para type="description">
+        /// The list of instance tags applied to each nodes.
+        /// Tags are used to identify valid sources or targets for network firewalls.
+        /// </para>
+        [Parameter(Mandatory = false)]
+        public virtual string[] Tags { get; set; }
+
+        /// <para type="description">
+        /// The Google Cloud Platform Service Account to be used by the node VMs.
+        /// Use New-GceServiceAccountConfig to create the service account and appropriate scopes.
+        /// </para>
+        [Parameter(Mandatory = false)]
+        public virtual ServiceAccount ServiceAccount { get; set; }
+
+        /// <para type="description">
+        /// If set, every node created will be a preemptible VM instance.
+        /// </para>
+        [Parameter(Mandatory = false)]
+        public virtual SwitchParameter Preemptible { get; set; }
+
+        /// <summary>
+        /// Dictionary of image types with key as as tuple of project and zone
+        /// and value as the image types available in the project's zone.
+        /// This dictionary is used for caching the various image types available in a project's zone.
+        /// </summary>
+        private static ConcurrentDictionary<Tuple<string, string>, string[]> s_imageTypesDictionary =
+            new ConcurrentDictionary<Tuple<string, string>, string[]>();
+
+        /// <summary>
+        /// Dictionary of image types with key as as tuple of project and zone
+        /// and value as the machine types available in the project's zone.
+        /// This dictionary is used for caching the various machine types available in a project's zone.
+        /// </summary>
+        private static ConcurrentDictionary<Tuple<string, string>, string[]> s_machineTypesDictionary =
+            new ConcurrentDictionary<Tuple<string, string>, string[]>();
+
+        /// <summary>
+        /// This dynamic parameter dictionary is used by PowerShell to generate parameters dynamically.
+        /// </summary>
+        private RuntimeDefinedParameterDictionary _dynamicParameters;
+
+        /// <summary>
+        /// Generate dynamic parameter -MachineType and -ImageType based on the value of -Project
+        /// and -Zone. This will provide tab-completion for -MachineType and -ImageType parameters.
+        /// </summary>
+        public object GetDynamicParameters()
+        {
+            if (_dynamicParameters == null)
+            {
+                _dynamicParameters = new RuntimeDefinedParameterDictionary();
+
+                // Try to resolve Project variable to a string, use default value from the SDK if we fail to do so.
+                Project = GetCloudSdkSettingValue(CloudSdkSettings.CommonProperties.Project, Project);
+                // Try to resolve Zone variable to a string, use default value from the SDK if we fail to do so.
+                Zone = GetCloudSdkSettingValue(CloudSdkSettings.CommonProperties.Zone, Zone);
+
+                PopulateDynamicParameter(Project, Zone, _dynamicParameters);
+            }
+
+            return _dynamicParameters;
+        }
+
+        /// <summary>
+        /// Using project and zone, create dynamic parameters (project and zone are used to make API call
+        /// to get valid set of values for the parameters) and populate the dynamic parameter dictionary.
+        /// </summary>
+        protected abstract void PopulateDynamicParameter(string project, string zone,
+            RuntimeDefinedParameterDictionary dynamicParamDict);
+
+        /// <summary>
+        /// Generate a RuntimeDefinedParameter based on the parameter name,
+        /// the help message and the valid set of parameter values.
+        /// </summary>
+        protected RuntimeDefinedParameter GenerateRuntimeParameter(
+            string parameterName,
+            string helpMessage,
+            string[] validSet,
+            string parameterSetName = null)
+        {
+            ParameterAttribute paramAttribute = new ParameterAttribute()
+            {
+                Mandatory = false,
+                HelpMessage = helpMessage
+            };
+            if (parameterSetName != null)
+            {
+                paramAttribute.ParameterSetName = parameterSetName;
+            }
+            List<Attribute> attributeLists = new List<Attribute>() { paramAttribute };
+
+            if (validSet.Length != 0)
+            {
+                var validateSetAttribute = new ValidateSetAttribute(validSet);
+                validateSetAttribute.IgnoreCase = true;
+                attributeLists.Add(validateSetAttribute);
+            }
+
+            Collection<Attribute> attributes = new Collection<Attribute>(attributeLists);
+            return new RuntimeDefinedParameter(parameterName, typeof(string), attributes);
+        }
+
+        /// <summary>
+        /// Returns all the possible image types in a given zone in a given project.
+        /// </summary>
+        protected string[] GetImageTypes(string project, string zone)
+        {
+            Tuple<string, string> key = new Tuple<string, string>(project, zone);
+            if (!s_imageTypesDictionary.ContainsKey(key))
+            {
+                try
+                {
+                    ProjectsResource.ZonesResource.GetServerconfigRequest getConfigRequest =
+                        Service.Projects.Zones.GetServerconfig(project, zone);
+                    ServerConfig config = getConfigRequest.Execute();
+
+                    s_imageTypesDictionary[key] = config.ValidImageTypes.ToArray();
+                }
+                catch
+                {
+                    // Just swallow error and don't provide tab completion for -ImageType.
+                    s_imageTypesDictionary[key] = new string[] { };
+                }
+            }
+            return s_imageTypesDictionary[key];
+        }
+
+
+        /// <summary>
+        /// Returns all the possible machine types in a given zone in a given project.
+        /// </summary>
+        protected string[] GetMachineTypes(string project, string zone)
+        {
+            Tuple<string, string> key = new Tuple<string, string>(project, zone);
+            if (!s_machineTypesDictionary.ContainsKey(key))
+            {
+                List<string> machineTypes = new List<string>();
+                try
+                {
+                    Apis.Compute.v1.MachineTypesResource.ListRequest listRequest =
+                        _computeService.Value.MachineTypes.List(project, zone);
+                    do
+                    {
+                        MachineTypeList response = listRequest.Execute();
+                        if (response.Items != null)
+                        {
+                            machineTypes.AddRange(response.Items.Select(machineType => machineType.Name));
+                        }
+                        listRequest.PageToken = response.NextPageToken;
+                    }
+                    while (listRequest.PageToken != null);
+                }
+                catch
+                {
+                    // Just swallow error.
+                }
+                s_machineTypesDictionary[key] = machineTypes.ToArray();
+            }
+            return s_machineTypesDictionary[key];
+        }
+
+        /// <summary>
+        /// Returns the machine type that the user selected.
+        /// </summary>
+        protected string SelectedMachineType
+        {
+            get
+            {
+                if (_dynamicParameters.ContainsKey("MachineType"))
+                {
+                    return _dynamicParameters["MachineType"].Value?.ToString().ToLower();
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns the image type that the user selected.
+        /// </summary>
+        protected string SelectedImageType
+        {
+            get
+            {
+                if (_dynamicParameters.ContainsKey("ImageType"))
+                {
+                    return _dynamicParameters["ImageType"].Value?.ToString().ToLower();
+                }
+                return null;
+            }
+        }
+
+        protected NodeConfig BuildNodeConfig()
+        {
+            var nodeConfig = new NodeConfig()
+            {
+                DiskSizeGb = DiskSizeGb,
+                LocalSsdCount = LocalSsdCount,
+                Tags = Tags,
+                ServiceAccount = ServiceAccount?.Email,
+                OauthScopes = ServiceAccount?.Scopes,
+                Preemptible = Preemptible.ToBool(),
+                MachineType = SelectedMachineType,
+                ImageType = SelectedImageType
+            };
+
+            if (Label != null)
+            {
+                nodeConfig.Labels = ConvertToDictionary<string, string>(Label);
+            }
+
+            if (InstanceMetadata != null)
+            {
+                /// Metadata key/value pairs assigned to instances in the cluster.
+                /// Keys must conform to the regexp [a-zA-Z0-9-_]+ and not conflict with any other
+                /// metadata keys for the project or be one of the four reserved keys: "instance-template",
+                /// "kube-env", "startup-script" and "user-data".
+                Dictionary<string, string> metadataDict = ConvertToDictionary<string, string>(InstanceMetadata);
+                foreach (string key in metadataDict.Keys)
+                {
+                    if (!s_metadataKeyRegex.IsMatch(key))
+                    {
+                        ThrowTerminatingError(new ErrorRecord(
+                            new ArgumentException("Metadata key can only be alphanumeric, hyphen or underscore."),
+                            "InvalidMetadataKey",
+                            ErrorCategory.InvalidArgument,
+                            key));
+                    }
+
+                    if (s_reservedMetadataKey.Contains(key, StringComparer.OrdinalIgnoreCase))
+                    {
+                        ThrowTerminatingError(new ErrorRecord(
+                            new ArgumentException($"Metadata key '{key}' is a reserved keyword."),
+                            "InvalidMetadataKey",
+                            ErrorCategory.InvalidArgument,
+                            key));
+                    }
+                }
+                nodeConfig.Metadata = metadataDict;
+            }
+
+            return nodeConfig;
+        }
+    }
+
+    /// <summary>
     /// <para type="synopsis">
     /// Creates a Google Container Engine Node Config.
     /// </para>
     /// <para type="description">
     /// Creates a Google Container Engine Node Config. The node config is used to configure various properties
-    /// of a node in a container cluster so you can use the object returned by the cmdlet in New-GkeCluster
+    /// of a node in a container cluster so you can use the object returned by the cmdlet in Add-GkeCluster
     /// to create a container cluster. If -Project is not used, the cmdlet will use the default project.
     /// If -Zone is not used, the cmdlet will use the default zone. -Project and -Zone parameters are only
     /// used to provide tab-completion for the possible list of image and machine types applicable to the nodes.
@@ -232,326 +553,31 @@ namespace Google.PowerShell.Container
     /// </para>
     /// </summary>
     [Cmdlet(VerbsCommon.New, "GkeNodeConfig")]
-    public class NewGkeNodeConfig : GkeCmdlet, IDynamicParameters
+    public class NewGkeNodeConfig : GkeNodeConfigCmdlet
     {
-        // IAM Service used for getting roles that can be granted to a project.
-        private Lazy<ComputeService> _computeService =
-            new Lazy<ComputeService>(() => new ComputeService(GetBaseClientServiceInitializer()));
-
-        // Regex that is used to check metadata key.
-        private static readonly Regex s_metadataKeyRegex = new Regex("[a-zA-Z0-9-_]+");
-
-        // Reserved key word for metadata key.
-        private static readonly string[] s_reservedMetadataKey =
-            new string[] { "instance-template", "kube-env", "startup-script", "user-data" };
-
-        /// <summary>
-        /// <para type="description">
-        /// The project that the node config belongs to.
-        /// This parameter defaults to the project in the Cloud SDK config.
-        /// </para>
-        /// </summary>
-        [Parameter(Mandatory = false)]
-        [ConfigPropertyName(CloudSdkSettings.CommonProperties.Project)]
-        public override string Project { get; set; }
-
-        /// <summary>
-        /// <para type="description">
-        /// The zone that the node config belongs to.
-        /// This parameter defaults to the project in the Cloud SDK config.
-        /// </para>
-        /// </summary>
-        [Parameter]
-        [ConfigPropertyName(CloudSdkSettings.CommonProperties.Zone)]
-        public string Zone { get; set; }
-
-        /// <summary>
-        /// <para type="description">
-        /// Size of the disk attached to each node, specified in GB.
-        /// The smallest allowed disk size is 10GB.
-        /// The default disk size is 100GB.
-        /// </para>
-        /// </summary>
-        [Parameter(Mandatory = false)]
-        [ValidateRange(10, int.MaxValue)]
-        public int? DiskSizeGb { get; set; }
-
-        /// <summary>
-        /// <para type="description">
-        /// Metadata key/value pairs assigned to instances in the cluster.
-        /// Keys must conform to the regexp [a-zA-Z0-9-_]+ and not conflict with any other
-        /// metadata keys for the project or be one of the four reserved keys: "instance-template",
-        /// "kube-env", "startup-script" and "user-data".
-        /// </para>
-        /// </summary>
-        [Parameter(Mandatory = false)]
-        [Alias("Metadata")]
-        public Hashtable InstanceMetadata { get; set; }
-
-        /// <summary>
-        /// <para type="description">
-        /// The map of Kubernetes labels (key/value pairs) to be applied to each node.
-        /// This is in addition to any default label(s) that Kubernetes may apply to the node.
-        /// </para>
-        /// </summary>
-        [Parameter(Mandatory = false)]
-        public Hashtable Label { get; set; }
-
-        /// <summary>
-        /// <para type="description">
-        /// The number of local SSD disks attached to each node.
-        /// </para>
-        /// </summary>
-        [Parameter(Mandatory = false)]
-        [ValidateRange(0, int.MaxValue)]
-        public int? LocalSsdCount { get; set; }
-
-        /// <para type="description">
-        /// The list of instance tags applied to each nodes.
-        /// Tags are used to identify valid sources or targets for network firewalls.
-        /// </para>
-        [Parameter(Mandatory = false)]
-        public string[] Tags { get; set; }
-
-        /// <para type="description">
-        /// The Google Cloud Platform Service Account to be used by the node VMs.
-        /// Use New-GceServiceAccountConfig to create the service account and appropriate scopes.
-        /// </para>
-        [Parameter(Mandatory = false)]
-        public ServiceAccount ServiceAccount { get; set; }
-
-        [Parameter(Mandatory = false)]
-        public SwitchParameter Preemptible { get; set; }
-
-        /// <summary>
-        /// This dynamic parameter dictionary is used by PowerShell to generate parameters dynamically.
-        /// </summary>
-        private RuntimeDefinedParameterDictionary _dynamicParameters;
-
-        /// <summary>
-        /// Dictionary of image types with key as project and zone (combined as {project}###{zone})
-        /// and value as the image types available in the project's zone.
-        /// This dictionary is used for caching the various image types available in a project's zone.
-        /// </summary>
-        private static ConcurrentDictionary<string, string[]> s_imageTypesDictionary =
-            new ConcurrentDictionary<string, string[]>();
-
-        /// <summary>
-        /// Dictionary of machine types with key as project and zone (combined as {project}###{zone})
-        /// and value as the machine types available in the project's zone.
-        /// This dictionary is used for caching the various machine types available in a project's zone.
-        /// </summary>
-        private static ConcurrentDictionary<string, string[]> s_machineTypesDictionary =
-            new ConcurrentDictionary<string, string[]>();
-
-        /// <summary>
-        /// Generate dynamic parameter -MachineType and -ImageType based on the value of -Project
-        /// and -Zone. This will provide tab-completion for -MachineType and -ImageType parameters.
-        /// </summary>
-        public object GetDynamicParameters()
+        protected override void PopulateDynamicParameter(string project, string zone,
+            RuntimeDefinedParameterDictionary dynamicParamDict)
         {
-            if (_dynamicParameters == null)
-            {
-                _dynamicParameters = new RuntimeDefinedParameterDictionary();
+            // Gets all the valid machine types of this zone and project combination.
+            string[] machineTypes = GetMachineTypes(Project, Zone);
+            RuntimeDefinedParameter machineTypeParam = GenerateRuntimeParameter(
+                parameterName: "MachineType",
+                helpMessage: "The Google Compute Engine machine type to use for this node.",
+                validSet: machineTypes);
+            dynamicParamDict.Add("MachineType", machineTypeParam);
 
-                // Try to resolve Project variable to a string, use default value from the SDK if we fail to do so.
-                Project = GetCloudSdkSettingValue(CloudSdkSettings.CommonProperties.Project, Project);
-                // Try to resolve Zone variable to a string, use default value from the SDK if we fail to do so.
-                Zone = GetCloudSdkSettingValue(CloudSdkSettings.CommonProperties.Zone, Zone);
-
-                // Gets all the valid machine types of this zone and project combination.
-                string[] machineTypes = GetMachineTypes(Project, Zone);
-                RuntimeDefinedParameter machineTypeParam = GenerateImageTypeParameter(
-                    parameterName: "MachineType",
-                    helpMessage: "The Google Compute Engine machine type to use for this node.",
-                    validSet: machineTypes);
-                _dynamicParameters.Add("MachineType", machineTypeParam);
-
-                // Gets all the valid image types of this zone and project combination.
-                string[] imageTypes = GetImageTypes(Project, Zone);
-                RuntimeDefinedParameter imageTypeParam = GenerateImageTypeParameter(
-                    parameterName: "ImageType",
-                    helpMessage: "The image type to use for this node.",
-                    validSet: imageTypes);
-                _dynamicParameters.Add("ImageType", imageTypeParam);
-            }
-
-            return _dynamicParameters;
-        }
-
-        /// <summary>
-        /// Generate a RuntimeDefinedParameter based on the parameter name,
-        /// the help message and the valid set of parameter values.
-        /// </summary>
-        private RuntimeDefinedParameter GenerateImageTypeParameter(
-            string parameterName,
-            string helpMessage,
-            string[] validSet)
-        {
-            ParameterAttribute paramAttribute = new ParameterAttribute()
-            {
-                Mandatory = false,
-                HelpMessage = helpMessage
-            };
-            List<Attribute> attributeLists = new List<Attribute>() { paramAttribute };
-
-            if (validSet.Length != 0)
-            {
-                var validateSetAttribute = new ValidateSetAttribute(validSet);
-                validateSetAttribute.IgnoreCase = true;
-                attributeLists.Add(validateSetAttribute);
-            }
-
-            Collection<Attribute> attributes = new Collection<Attribute>(attributeLists);
-            return new RuntimeDefinedParameter(parameterName, typeof(string), attributes);
-        }
-
-        /// <summary>
-        /// Returns all the possible image types in a given zone in a given project.
-        /// </summary>
-        private string[] GetImageTypes(string project, string zone)
-        {
-            string key = $"{project}###{zone}";
-            if (!s_imageTypesDictionary.ContainsKey(key))
-            {
-                try
-                {
-                    ProjectsResource.ZonesResource.GetServerconfigRequest getConfigRequest =
-                        Service.Projects.Zones.GetServerconfig(project, zone);
-                    ServerConfig config = getConfigRequest.Execute();
-
-                    s_imageTypesDictionary[key] = config.ValidImageTypes.ToArray();
-                }
-                catch
-                {
-                    // Just swallow error and don't provide tab completion for -ImageType.
-                    s_imageTypesDictionary[key] = new string[] { };
-                }
-            }
-            return s_imageTypesDictionary[key];
-        }
-
-
-        /// <summary>
-        /// Returns all the possible machine types in a given zone in a given project.
-        /// </summary>
-        private string[] GetMachineTypes(string project, string zone)
-        {
-            string key = $"{project}###{zone}";
-            if (!s_machineTypesDictionary.ContainsKey(key))
-            {
-                List<string> machineTypes = new List<string>();
-                try
-                {
-                    string pageToken = null;
-                    do
-                    {
-                        Apis.Compute.v1.MachineTypesResource.ListRequest listRequest =
-                            _computeService.Value.MachineTypes.List(project, zone);
-                        listRequest.PageToken = pageToken;
-                        MachineTypeList response = listRequest.Execute();
-                        if (response.Items != null)
-                        {
-                            machineTypes.AddRange(response.Items.Select(machineType => machineType.Name));
-                        }
-                        pageToken = response.NextPageToken;
-                    }
-                    while (pageToken != null);
-                }
-                catch
-                {
-                    // Just swallow error.
-                }
-                s_machineTypesDictionary[key] = machineTypes.ToArray();
-            }
-            return s_machineTypesDictionary[key];
-        }
-
-        /// <summary>
-        /// Returns the machine type that the user selected.
-        /// </summary>
-        private string SelectedMachineType
-        {
-            get
-            {
-                if (_dynamicParameters.ContainsKey("MachineType"))
-                {
-                    return _dynamicParameters["MachineType"].Value?.ToString().ToLower();
-                }
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Returns the image type that the user selected.
-        /// </summary>
-        private string SelectedImageType
-        {
-            get
-            {
-                if (_dynamicParameters.ContainsKey("ImageType"))
-                {
-                    return _dynamicParameters["ImageType"].Value?.ToString().ToLower();
-                }
-                return null;
-            }
+            // Gets all the valid image types of this zone and project combination.
+            string[] imageTypes = GetImageTypes(Project, Zone);
+            RuntimeDefinedParameter imageTypeParam = GenerateRuntimeParameter(
+                parameterName: "ImageType",
+                helpMessage: "The image type to use for this node.",
+                validSet: imageTypes);
+            dynamicParamDict.Add("ImageType", imageTypeParam);
         }
 
         protected override void ProcessRecord()
         {
             WriteObject(BuildNodeConfig());
-        }
-
-        private NodeConfig BuildNodeConfig()
-        {
-            var nodeConfig = new NodeConfig()
-            {
-                DiskSizeGb = DiskSizeGb,
-                LocalSsdCount = LocalSsdCount,
-                Tags = Tags,
-                ServiceAccount = ServiceAccount?.Email,
-                OauthScopes = ServiceAccount?.Scopes,
-                Preemptible = Preemptible.ToBool(),
-                MachineType = SelectedMachineType,
-                ImageType = SelectedImageType
-            };
-
-            if (Label != null)
-            {
-                nodeConfig.Labels = ConvertToDictionary<string, string>(Label);
-            }
-
-            if (InstanceMetadata != null)
-            {
-                /// Metadata key/value pairs assigned to instances in the cluster.
-                /// Keys must conform to the regexp [a-zA-Z0-9-_]+ and not conflict with any other
-                /// metadata keys for the project or be one of the four reserved keys: "instance-template",
-                /// "kube-env", "startup-script" and "user-data".
-                Dictionary<string, string> metadataDict = ConvertToDictionary<string, string>(InstanceMetadata);
-                foreach (string key in metadataDict.Keys)
-                {
-                    if (!s_metadataKeyRegex.IsMatch(key))
-                    {
-                        ThrowTerminatingError(new ErrorRecord(
-                            new ArgumentException("Metadata key can only be alphanumeric, hyphen or underscore."),
-                            "InvalidMetadataKey",
-                            ErrorCategory.InvalidArgument,
-                            key));
-                    }
-
-                    if (s_reservedMetadataKey.Contains(key, StringComparer.OrdinalIgnoreCase))
-                    {
-                        ThrowTerminatingError(new ErrorRecord(
-                            new ArgumentException($"Metadata key '{key}' is a reserved keyword."),
-                            "InvalidMetadataKey",
-                            ErrorCategory.InvalidArgument,
-                            key));
-                    }
-                }
-                nodeConfig.Metadata = metadataDict;
-            }
-
-            return nodeConfig;
         }
     }
 }


### PR DESCRIPTION
This cmdlet creates a Google Container NodeConfig object. This object will be used in the cmdlet New-GkeContainerCluster (to be created after this) to configure nodes in a container cluster.
Also enable New-GceServiceAccountConfig to use the project's [default service account](https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_default_service_account) when service account email is not provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/497)
<!-- Reviewable:end -->
