### PR TITLE
Fix a bug where Get-GcdResourceRecordSet is not paging through the results.

### DIFF
--- a/Google.PowerShell/Provider/GoogleCloudStorageProvider.cs
+++ b/Google.PowerShell/Provider/GoogleCloudStorageProvider.cs
@@ -1079,7 +1079,9 @@ namespace Google.PowerShell.CloudStorage
                     request.PageToken = buckets.NextPageToken;
                 } while (request.PageToken != null);
             }
-            catch (GoogleApiException e) when (e.HttpStatusCode == HttpStatusCode.Forbidden) { }
+            // Swallow any GoogleApiException when listing a bucket for projects, otherwise, if user has an
+            // erroneous project, this will stop the execution of Get-ChildItem for other projects.
+            catch (GoogleApiException) { }
         }
 
         private static IEnumerable<Project> ListAllProjects()


### PR DESCRIPTION
Also, prevent Get-ChildItem from throwing error for erroneous project for PowerShell Cloud Storage Provider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/500)
<!-- Reviewable:end -->
