### PR TITLE
Fix tests failure and remove -OutputVersionFormat from LogSink cmdlet

### DIFF
--- a/Google.PowerShell.IntegrationTests/BigQuery/BigQuery.BqJob.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/BigQuery/BigQuery.BqJob.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿. $PSScriptRoot\..\BigQuery\BqCmdlets.ps1
 $project, $zone, $oldActiveConfig, $configName = Set-GCloudConfig
+$folder = Resolve-Path $PSScriptRoot
 
 Describe "Get-BqJob" {
 
@@ -7,8 +8,6 @@ Describe "Get-BqJob" {
         $r = Get-Random
         $datasetName = "pshell_testing_$r"
         $test_set = New-BqDataset $datasetName
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename = "$folder\classics.csv"
         $table = New-BqTable -Dataset $test_Set "table_$r"
         New-BqSchema "Title" "STRING" | New-BqSchema "Author" "STRING" | New-BqSchema "Year" "INTEGER" | 
@@ -75,8 +74,6 @@ Describe "BqJob-Query" {
         $r = Get-Random
         $datasetName = "pshell_testing_$r"
         $test_set = New-BqDataset $datasetName
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename = "$folder\classics.csv"
         $table = New-BqTable -Dataset $test_Set "table_$r"
         New-BqSchema "Title" "STRING" | New-BqSchema "Author" "STRING" | New-BqSchema "Year" "INTEGER" | 
@@ -146,8 +143,6 @@ Describe "BqJob-Copy" {
         $r = Get-Random
         $datasetName = "pshell_testing_$r"
         $test_set = New-BqDataset $datasetName
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename = "$folder\classics.csv"
         $filename_other = "$folder\otherschema.csv"
 
@@ -222,8 +217,6 @@ Describe "BqJob-Extract-Load" {
         $r = Get-Random
         $datasetName = "pshell_testing_$r"
         $test_set = New-BqDataset $datasetName
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename = "$folder\classics.csv"
         $table = New-BqTable -Dataset $test_Set "table_$r"
         New-BqSchema "Title" "STRING" | New-BqSchema "Author" "STRING" | New-BqSchema "Year" "INTEGER" | 
@@ -365,8 +358,6 @@ Describe "Stop-BqJob" {
         $r = Get-Random
         $datasetName = "pshell_testing_$r"
         $test_set = New-BqDataset $datasetName
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename = "$folder\classics_large.csv"
         $table = New-BqTable -Dataset $test_Set "table_$r"
         New-BqSchema "Title" "STRING" | New-BqSchema "Author" "STRING" | New-BqSchema "Year" "INTEGER" | 

--- a/Google.PowerShell.IntegrationTests/BigQuery/BigQuery.BqTable.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/BigQuery/BigQuery.BqTable.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿. $PSScriptRoot\..\BigQuery\BqCmdlets.ps1
 $project, $zone, $oldActiveConfig, $configName = Set-GCloudConfig
+$folder = Resolve-Path $PSScriptRoot
 
 Describe "Get-BqTable" {
 
@@ -271,8 +272,6 @@ Describe "Remove-BqTable" {
     }
 
     It "should delete a nonempty table as long as -Force is specified" {
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename_csv = "$folder\classics.csv"
         $schema = New-BqSchema -Name "Title" -Type "STRING" | New-BqSchema -Name "Author" -Type "STRING" |
                   New-BqSchema -Name "Year" -Type "INTEGER" | Set-BqSchema

--- a/Google.PowerShell.IntegrationTests/BigQuery/BigQuery.BqTableRow.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/BigQuery/BigQuery.BqTableRow.Tests.ps1
@@ -1,11 +1,10 @@
 . $PSScriptRoot\..\BigQuery\BqCmdlets.ps1
 $project, $zone, $oldActiveConfig, $configName = Set-GCloudConfig
+$folder = Resolve-Path $PSScriptRoot
 
 Describe "New-BqSchema" {
 
     BeforeAll {
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename = "$folder\schema.json"
         $filename_mini = "$folder\schema_mini.json"
     }
@@ -81,8 +80,6 @@ Describe "Set-BqSchema" {
         $r = Get-Random
         $datasetName = "pshell_testing_$r"
         $test_set = New-BqDataset $datasetName
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename = "$folder\schema.json"
     }
 
@@ -154,8 +151,6 @@ Describe "Add-BqTableRow" {
         $datasetName = "pshell_testing_$r"
         $test_set = New-BqDataset $datasetName
         # Input file path setup.
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename_csv = "$folder\classics.csv"
         $filename_json = "$folder\classics.json"
         $filename_avro = "$folder\classics.avro"
@@ -270,8 +265,6 @@ Describe "Get-BqTableRow" {
         $datasetName = "pshell_testing_$r"
         $test_set = New-BqDataset $datasetName
         # Input file path setup.
-        $folder = Get-Location
-        $folder = $folder.ToString()
         $filename = "$folder\classics.csv"
         $filename_big = "$folder\classics_large.csv"
         # Small Table Setup.

--- a/Google.PowerShell.IntegrationTests/Logging/Logging.GcLogSink.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Logging/Logging.GcLogSink.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Get-GcLogSink" {
     $destinationTwo = "storage.googleapis.com/random-destination-will-do2-$r"
     $logFilter = "this is a filter"
     gcloud beta logging sinks create $script:sinkName $destination --log-filter=$logFilter --quiet 2>$null
-    gcloud beta logging sinks create $script:secondSinkName $destinationTwo --output-version-format=V2 --quiet 2>$null
+    gcloud beta logging sinks create $script:secondSinkName $destinationTwo --quiet 2>$null
     
 
     AfterAll {
@@ -29,7 +29,7 @@ Describe "Get-GcLogSink" {
         $firstSink = $sinks | Where-Object {$_.Name -eq $sinkName}
         $firstSink | Should Not BeNullOrEmpty
         $firstSink.Destination | Should BeExactly $destination
-        $firstSink.OutputVersionFormat | Should BeExactly V1
+        $firstSink.OutputVersionFormat | Should BeExactly V2
         $firstSink.Filter | Should BeExactly $logFilter
         $firstSink.WriterIdentity | Should Not BeNullOrEmpty
 
@@ -46,7 +46,7 @@ Describe "Get-GcLogSink" {
         $firstSink | Should Not BeNullOrEmpty
         $firstSink.Name | Should BeExactly "$sinkName"
         $firstSink.Destination | Should BeExactly $destination
-        $firstSink.OutputVersionFormat | Should BeExactly V1
+        $firstSink.OutputVersionFormat | Should BeExactly V2
         $firstSink.Filter | Should BeExactly $logFilter
         $firstSink.WriterIdentity | Should Not BeNullOrEmpty
     }
@@ -58,7 +58,7 @@ Describe "Get-GcLogSink" {
         $firstSink = $sinks | Where-Object {$_.Name -eq $sinkName}
         $firstSink | Should Not BeNullOrEmpty
         $firstSink.Destination | Should BeExactly $destination
-        $firstSink.OutputVersionFormat | Should BeExactly V1
+        $firstSink.OutputVersionFormat | Should BeExactly V2
         $firstSink.Filter | Should BeExactly $logFilter
         $firstSink.WriterIdentity | Should Not BeNullOrEmpty
 
@@ -171,20 +171,19 @@ Describe "New-GcLogSink" {
 
     It "should work with -OutputVersionFormat" {
         $r = Get-Random
-        $bucket = "gcloud-powershell-testing-pubsubtopicv1-$r"
-        $bucketTwo = "gcloud-powershell-testing-pubsubtopicv2-$r"
+        $bucket = "gcloud-powershell-testing-pubsubtopic-1-$r"
+        $bucketTwo = "gcloud-powershell-testing-pubsubtopic-2-$r"
         $sinkName = "gcps-new-gclogsink-$r"
         $sinkNameTwo = "gcps-new-gclogsink2-$r"
         try {
-            New-GcLogSink $sinkName -GcsBucketDestination $bucket -OutputVersionFormat V1 -UniqueWriterIdentity
-            # Have to be a different topic because sinks with diffferent output formats cannot share destination.
-            New-GcLogSink $sinkNameTwo -GcsBucketDestination $bucketTwo -OutputVersionFormat V2 -UniqueWriterIdentity
+            New-GcLogSink $sinkName -GcsBucketDestination $bucket -UniqueWriterIdentity
+            New-GcLogSink $sinkNameTwo -GcsBucketDestination $bucketTwo -UniqueWriterIdentity
             Start-Sleep -Seconds 1
 
             $createdSink = Get-GcLogSink -Sink $sinkName
             Test-GcLogSink -Name $sinkName `
                            -Destination "storage.googleapis.com/$bucket" `
-                           -OutputVersionFormat "V1" `
+                           -OutputVersionFormat "V2" `
                            -Sink $createdSink
 
             $createdSink = Get-GcLogSink -Sink $sinkNameTwo
@@ -523,18 +522,18 @@ Describe "Set-GcLogSink" {
 
     It "should work with -OutputVersionFormat" {
         $r = Get-Random
-        $bucket = "gcloud-powershell-testing-pubsubtopicv1-$r"
-        $bucketTwo = "gcloud-powershell-testing-pubsubtopicv2-$r"
+        $bucket = "gcloud-powershell-testing-pubsubtopic-1-$r"
+        $bucketTwo = "gcloud-powershell-testing-pubsubtopic-2-$r"
         $sinkName = "gcps-new-gclogsink-$r"
         $sinkNameTwo = "gcps-new-gclogsink2-$r"
         try {
-            New-GcLogSink $sinkName -GcsBucketDestination $bucket -OutputVersionFormat V1 -UniqueWriterIdentity
+            New-GcLogSink $sinkName -GcsBucketDestination $bucket -UniqueWriterIdentity
             # Have to be a different topic because sinks with diffferent output formats cannot share destination.
-            New-GcLogSink $sinkNameTwo -GcsBucketDestination $bucketTwo -OutputVersionFormat V2 -UniqueWriterIdentity
+            New-GcLogSink $sinkNameTwo -GcsBucketDestination $bucketTwo -UniqueWriterIdentity
             Start-Sleep -Seconds 1
 
             Set-GcLogSink $sinkName -OutputVersionFormat V2 -UniqueWriterIdentity
-            Set-GcLogSink $sinkNameTwo -GcsBucketDestination $bucketTwo -OutputVersionFormat V1 -UniqueWriterIdentity
+            Set-GcLogSink $sinkNameTwo -GcsBucketDestination $bucketTwo -UniqueWriterIdentity
             Start-Sleep -Seconds 1
 
             $updatedSink = Get-GcLogSink -Sink $sinkName
@@ -546,7 +545,7 @@ Describe "Set-GcLogSink" {
             $updatedSink = Get-GcLogSink -Sink $sinkNameTwo
             Test-GcLogSink -Name $sinkNameTwo `
                            -Destination "storage.googleapis.com/$bucketTwo" `
-                           -OutputVersionFormat "V1" `
+                           -OutputVersionFormat "V2" `
                            -Sink $updatedSink
         }
         finally {

--- a/Google.PowerShell/Logging/GcLogSinkCmdlets.cs
+++ b/Google.PowerShell/Logging/GcLogSinkCmdlets.cs
@@ -137,15 +137,6 @@ namespace Google.PowerShell.Logging
 
         /// <summary>
         /// <para type="description">
-        /// The log entry format to use for this sink's exported log entries. The v2 format is used by default.
-        /// The v1 format is deprecated and should be used only as part of a migration effort to v2.
-        /// </para>
-        /// </summary>
-        [Parameter(Mandatory = false)]
-        public LogEntryVersionFormat? OutputVersionFormat { get; set; }
-
-        /// <summary>
-        /// <para type="description">
         /// The name of the sink to be created. This name must be unique within the project.
         /// </para>
         /// </summary>
@@ -229,11 +220,6 @@ namespace Google.PowerShell.Logging
                 before: null,
                 after: null,
                 otherFilter: Filter);
-
-            if (OutputVersionFormat.HasValue)
-            {
-                logSink.OutputVersionFormat = Enum.GetName(typeof(LogEntryVersionFormat), OutputVersionFormat.Value).ToUpper();
-            }
 
             if (Before.HasValue)
             {


### PR DESCRIPTION
Remove -OutputVersionFormat as V1 LogSink is deprecated (this cmdlet is still in beta).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/529)
<!-- Reviewable:end -->
