### PR TITLE
Adds the gs:() function.

### DIFF
--- a/Google.PowerShell.IntegrationTests/Provider/Storage.Provider.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Provider/Storage.Provider.Tests.ps1
@@ -28,6 +28,12 @@ Describe "Storage Provider"{
         cd gs:\ 2>&1 | Should BeNullOrEmpty
     }
 
+    It "Should change directory from function" {
+        cd c:
+        gs:
+        $PWD.Path | Should Be "gs:\"
+    }
+
     It "Should make bucket" {
         cd gs:\
         Test-Path $bucketName | Should Be $false

--- a/Google.PowerShell.IntegrationTests/Provider/Storage.Provider.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Provider/Storage.Provider.Tests.ps1
@@ -29,6 +29,7 @@ Describe "Storage Provider"{
     }
 
     It "Should change directory from function" {
+        cd gs:\
         cd c:
         gs:
         $PWD.Path | Should Be "gs:\"

--- a/Google.PowerShell/Google.PowerShell.csproj
+++ b/Google.PowerShell/Google.PowerShell.csproj
@@ -256,6 +256,7 @@
     </None>
     <None Include="README.md" />
     <None Include="ReleaseFiles\BootstrapCloudToolsForPowerShell.ps1" />
+    <None Include="ReleaseFiles\GoogleCloud.psm1" />
     <None Include="ReleaseFiles\GoogleCloudPowerShell.psd1" />
     <None Include="ReleaseFiles\GoogleCloudPlatform.Format.ps1xml" />
     <None Include="ReleaseFiles\GoogleCloud.psd1" />

--- a/Google.PowerShell/ReleaseFiles/GoogleCloud.psd1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloud.psd1
@@ -66,7 +66,7 @@ FormatsToProcess = 'GoogleCloudPlatform.Format.ps1xml'
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @()
+FunctionsToExport = @('gs:')
 
 # Cmdlets to export from this module
 CmdletsToExport = '*'

--- a/Google.PowerShell/ReleaseFiles/GoogleCloud.psm1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloud.psm1
@@ -143,3 +143,14 @@ function Install-GCloudSdkSilently() {
 
 Install-GCloudSdk
 Import-Module "$script:GCloudModulePath\Google.PowerShell.dll"
+
+function gs:() {
+    <#
+    .SYNOPSIS
+    Changes the directory to the Google Cloud Storage drive.
+    .DESCRIPTION
+    This function changes the directory to the Google Cloud Storage drive.
+    It can be called before the Google Cloud PowerShell module is imported.
+    #>
+    cd gs:
+}


### PR DESCRIPTION
This lets the user change the directory to gs:\ before loading the module (and therefore the provider).