### PR TITLE
Fix .Net Core build.

### DIFF
--- a/Google.PowerShell.DotnetCore/Google.PowerShell.DotnetCore.csproj
+++ b/Google.PowerShell.DotnetCore/Google.PowerShell.DotnetCore.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Google.PowerShell\Common\*.cs;..\Google.PowerShell\Compute\*.cs;..\Google.PowerShell\Dns\*.cs;..\Google.PowerShell\Properties\*.cs;..\Google.PowerShell\Provider\*.cs;..\Google.PowerShell\Sql\*.cs;..\Google.PowerShell\Storage\*.cs;..\Google.PowerShell\Logging\*.cs;..\Google.PowerShell\PubSub\*.cs;..\Google.PowerShell\BigQuery\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    <Compile Include="..\Google.PowerShell\**\*.cs" Exclude="..\**\bin\**;..\**\obj\**;**\*.xproj;packages\**;..\Google.PowerShell\CloudResourceManager\IamPolicyCmdlets.cs;..\Google.PowerShell\Container\*" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Linux' ">

--- a/Nuget.config
+++ b/Nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="AppVeyor-PowerShell" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
The Dotnet core project was failing for me because of NuGet package issues. Add a new NuGet.Config at the solution root. Also, change the way the project imports the files to be less verbose.