### PR TITLE
Change tooling to package .NET Core module

### DIFF
--- a/Google.PowerShell/Common/GcloudWrapper.cs
+++ b/Google.PowerShell/Common/GcloudWrapper.cs
@@ -47,13 +47,11 @@ namespace Google.PowerShell.Common
         /// </summary>
         private static async Task<string> GetGCloudCommandOutput(string command, IDictionary<string, string> environment = null)
         {
-#if !UNIX
-            var actualCommand = $"gcloud {command} --format=json";
-            ProcessOutput processOutput = await ProcessUtils.GetCommandOutput("cmd.exe", $"/c \"{actualCommand}\"", environment);
-#else
-            var actualCommand = $"{command} --format=json";
-            ProcessOutput processOutput = await ProcessUtils.GetCommandOutput("gcloud", $"{actualCommand}", environment);
-#endif
+            var actualCommand = CloudSdkSettings.IsWindows ? $"gcloud {command} --format=json" : $"{command} --format=json";
+            ProcessOutput processOutput = CloudSdkSettings.IsWindows ?
+                await ProcessUtils.GetCommandOutput("cmd.exe", $"/c \"{actualCommand}\"", environment) :
+                await ProcessUtils.GetCommandOutput("gcloud", $"{actualCommand}", environment);
+
             if (processOutput.Succeeded)
             {
                 return processOutput.StandardOutput;

--- a/Google.PowerShell/Compute/GceSnapshotCmdlets.cs
+++ b/Google.PowerShell/Compute/GceSnapshotCmdlets.cs
@@ -99,10 +99,12 @@ namespace Google.PowerShell.Compute
         public string Description { get; set; }
 
         /// <summary>
+        /// <para type="description">
         /// If set, the snapshot created will be a Windows Volume Shadow Copy Service
         /// (VSS) snapshot. See:
         /// https://cloud.google.com/compute/docs/instances/windows/creating-windows-persistent-disk-snapshot?hl=en_US
         /// for more details.
+        /// </para>
         /// </summary>
         [Parameter]
         [Alias("VSS")]

--- a/Google.PowerShell/ReleaseFiles/GoogleCloud.psm1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloud.psm1
@@ -62,10 +62,10 @@ function Install-GCloudSdk {
     }
 
     Write-Host "Google Cloud SDK is not found in PATH. The SDK is required to run the module."
-    $noPrompt = $env:GCLOUD_SDK_INSTALLATION_NO_PROMPT -eq $true
+    $noPrompt = $env:GCLOUD_SDK_INSTALLATION_NO_PROMPT -eq $true -or $args -match "-?quiet"
 
     $query = "Do you want to install Google Cloud SDK? If you want to force the installation without prompt," +
-             " set `$env:GCLOUD_SDK_INSTALLATION_NO_PROMPT to true."
+             " set `$env:GCLOUD_SDK_INSTALLATION_NO_PROMPT to true or add '-quiet' to Import-Module -ArgumentList."
     $caption = "Installing Google Cloud SDK"
 
     $uiQuery = "Do you want to use the interactive installer? Select no to install silently on the command line."

--- a/Google.PowerShell/ReleaseFiles/GoogleCloud.psm1
+++ b/Google.PowerShell/ReleaseFiles/GoogleCloud.psm1
@@ -1,6 +1,4 @@
-﻿param()
-
-$script:GCloudModule = $ExecutionContext.SessionState.Module
+﻿$script:GCloudModule = $ExecutionContext.SessionState.Module
 $script:GCloudModulePath = $script:GCloudModule.ModuleBase
 $script:GCloudSdkLicense = @"
 The Google Cloud SDK and its source code are licensed under Apache
@@ -37,6 +35,20 @@ $script:gCloudInitWarning = "You will have to restart the shell and/or run 'gclo
     "(if you haven't run it after installing the SDK) before the module can be used."
 $script:installingSdkActivity = "Installing Google Cloud SDK"
 
+# This function returns true if we are running PowerShell on Windows.
+function IsWindows() {
+    if ($PSVersionTable.PSEdition -ne "Core") {
+        return $true
+    }
+
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+        [System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        return $true
+    }
+
+    return $false
+}
+
 # Check and install Google Cloud SDK if it is not present. To install it non-interactively,
 # set GCLOUD_SDK_INSTALLATION_NO_PROMPT to $true.
 function Install-GCloudSdk {
@@ -50,10 +62,10 @@ function Install-GCloudSdk {
     }
 
     Write-Host "Google Cloud SDK is not found in PATH. The SDK is required to run the module."
-    $noPrompt = $env:GCLOUD_SDK_INSTALLATION_NO_PROMPT -eq $true -or $args -match "-?quiet"
+    $noPrompt = $env:GCLOUD_SDK_INSTALLATION_NO_PROMPT -eq $true
 
     $query = "Do you want to install Google Cloud SDK? If you want to force the installation without prompt," +
-             " set `$env:GCLOUD_SDK_INSTALLATION_NO_PROMPT to true or add '-quiet' to Import-Module -ArgumentList."
+             " set `$env:GCLOUD_SDK_INSTALLATION_NO_PROMPT to true."
     $caption = "Installing Google Cloud SDK"
 
     $uiQuery = "Do you want to use the interactive installer? Select no to install silently on the command line."
@@ -66,23 +78,7 @@ function Install-GCloudSdk {
         else {
             if ($PSCmdlet.ShouldContinue($query, $caption)) {
                 if ($PSCmdlet.ShouldContinue($uiQuery, $uiCaption)) {
-                    $cloudSdkInstaller = "https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe"
-                    $installerLocation = Join-Path $env:TMP "$([System.IO.Path]::GetRandomFileName()).exe"
-
-                    Write-Progress -Activity $installingSdkActivity `
-                                   -Status "Downloading interactive installer to $installerLocation."
-
-                    # Set this to hide the progress bar from Invoke-WebRequest, which is not very useful.
-                    $ProgressPreference = "SilentlyContinue"
-                    Invoke-WebRequest -Uri $cloudSdkInstaller -OutFile $installerLocation
-                    $ProgressPreference = "Continue"
-
-                    Write-Progress -Activity $installingSdkActivity `
-                                   -Status "Launching interactive installer. Blocking until installation is complete."
-                    Start-Process $installerLocation -Wait
-
-                    Write-Warning $gCloudInitWarning
-                    Write-Progress -Activity $installingSdkActivity -Completed
+                    Install-GCloudSdkInteractively
                 }
                 else {
                     Install-GCloudSdkSilently
@@ -93,8 +89,42 @@ function Install-GCloudSdk {
     }
 }
 
+function Install-GCloudSdkInteractively() {
+    if (IsWindows) {
+        $cloudSdkInstaller = "https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe"
+        $installerLocation = Join-Path $env:TMP "$([System.IO.Path]::GetRandomFileName()).exe"
+
+        Write-Progress -Activity $installingSdkActivity `
+                        -Status "Downloading interactive installer to $installerLocation."
+
+        # Set this to hide the progress bar from Invoke-WebRequest, which is not very useful.
+        $ProgressPreference = "SilentlyContinue"
+        Invoke-WebRequest -Uri $cloudSdkInstaller -OutFile $installerLocation
+        $ProgressPreference = "Continue"
+
+        Write-Progress -Activity $installingSdkActivity `
+                        -Status "Launching interactive installer. Blocking until installation is complete."
+        Start-Process $installerLocation -Wait
+        Write-Progress -Activity $installingSdkActivity -Completed
+    }
+    else {
+        curl https://sdk.cloud.google.com | bash
+    }
+    Write-Warning $gCloudInitWarning
+}
+
 function Install-GCloudSdkSilently() {
     Write-Host $GCloudSdkLicense
+
+    if (-not (IsWindows)) {
+        curl https://sdk.cloud.google.com | bash -s -- --disable-prompts
+        $cloudBinPath = "$HOME\google-cloud-sdk\bin"
+        $envPath = [System.Environment]::GetEnvironmentVariable("PATH")
+        if (-not $envPath.Contains($cloudBinPath)) {
+            [System.Environment]::SetEnvironmentVariable("PATH", "$($envPath):$cloudBinPath")
+        }
+        return
+    }
 
     # We use this method of installation instead of the installer because the installer does all the installation
     # in the background so we can't determine when it's done.
@@ -144,7 +174,15 @@ function Install-GCloudSdkSilently() {
 }
 
 Install-GCloudSdk
-Import-Module "$script:GCloudModulePath\Google.PowerShell.dll"
+
+# Import either .NET Core or .NET Full version of the module based on
+# the edition of PowerShell.
+if ($PSVersionTable.PSEdition -eq "Core") {
+    Import-Module "$script:GCloudModulePath\coreclr\Google.PowerShell.dll"
+}
+else {
+    Import-Module "$script:GCloudModulePath\fullclr\Google.PowerShell.dll"
+}
 
 function gs:() {
     <#


### PR DESCRIPTION
After this change, the `.\BuildAndPackage.ps1` script will package both the Core CLR and normal CLR bits into one module. The `GoogleCloud.psm1` file will pick which assembly to load based on the PowerShell runtime. This way, our module will work across the different platforms.

I also added logic to install Cloud SDK on Unix systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/571)
<!-- Reviewable:end -->
