### PR TITLE
Fix a bug where BootstrapCloudToolsForPowershell is not found by Cloud Tools For PowerShell app

### DIFF
--- a/Google.PowerShell/ReleaseFiles/BootstrapCloudToolsForPowerShell.ps1
+++ b/Google.PowerShell/ReleaseFiles/BootstrapCloudToolsForPowerShell.ps1
@@ -9,8 +9,7 @@ function Get-ScriptDirectory
     return Split-Path $invocation.MyCommand.Path
 }
 
-$modulePath = Join-Path (Get-ScriptDirectory) "GoogleCloud.psd1"
-Import-Module $modulePath
+Import-Module (Get-ScriptDirectory)
 
 $Env:UserProfile
 clear

--- a/Tools/BuildAndPackage.ps1
+++ b/Tools/BuildAndPackage.ps1
@@ -249,11 +249,16 @@ function ConfirmExists($relativePath) {
    }
 }
 
+# Move BootstrapCloudToolsForPowerShell.ps1 to the GoogleCloud folder as this is
+# where "Cloud Tools For PowerShell" program in the Cloud SDK is looking for it.
+Move-Item "$googleCloudDir\BootstrapCloudToolsForPowerShell.ps1" `
+          "$powerShellDir\GoogleCloud\BootstrapCloudToolsForPowerShell.ps1"
+
 ConfirmExists "PowerShell\GoogleCloud\$normalizedVersion\GoogleCloud.psd1"
 ConfirmExists "PowerShell\GoogleCloud\$normalizedVersion\fullclr\Google.PowerShell.dll"
 ConfirmExists "PowerShell\GoogleCloud\$normalizedVersion\coreclr\Google.PowerShell.dll"
 ConfirmExists "PowerShell\GoogleCloud\$normalizedVersion\GoogleCloud.psm1"
-ConfirmExists "PowerShell\GoogleCloud\$normalizedVersion\BootstrapCloudToolsForPowerShell.ps1"
+ConfirmExists "PowerShell\GoogleCloud\BootstrapCloudToolsForPowerShell.ps1"
 ConfirmExists "GoogleCloudPowerShell\GoogleCloudPowerShell.psd1"
 ConfirmExists "PowerShell\GoogleCloudBeta\$normalizedVersion\GoogleCloudBeta.psd1"
 ConfirmExists "PowerShell\GoogleCloudBeta\$normalizedVersion\GoogleCloud.psm1"


### PR DESCRIPTION
The issue is that the "Cloud Tools For PowerShell" application is looking for "BootstrapCloudToolsForPowerShell.ps1" at the wrong place. Also, the bootstrap script itself is importing the module with the wrong directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/596)
<!-- Reviewable:end -->
