### PR TITLE
Fix a bug where fixed type metadata is not handled properly in GCS Object cmdlets.

### DIFF
--- a/Google.PowerShell.IntegrationTests/Dns/Dns.GcdChange.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Dns/Dns.GcdChange.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Get-GcdChange" {
     }
 
     It "should fail to return changes of non-existent project" {
-        { Get-GcdChange -Project $nonExistProject -Zone $testZone1 } | Should Throw "404"
+        { Get-GcdChange -Project $nonExistProject -Zone $testZone1 } | Should Throw "403"
     }
 
     It "should give access errors as appropriate" {
@@ -86,7 +86,7 @@ Describe "Add-GcdChange" {
     $copyChange.Deletions = $null
 
     It "should fail to add a Change to a non-existent project" {
-        { Add-GcdChange -Project $nonExistProject $testZone1 $copyChange } | Should Throw "404"
+        { Add-GcdChange -Project $nonExistProject $testZone1 $copyChange } | Should Throw "403"
     }
 
     It "should give access errors as appropriate" {

--- a/Google.PowerShell.IntegrationTests/Dns/Dns.GcdManagedZone.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Dns/Dns.GcdManagedZone.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Get-GcdManagedZone" {
     }
 
     It "should fail to return ManagedZones of non-existent project" {
-        { Get-GcdManagedZone -Project $nonExistProject } | Should Throw "404"
+        { Get-GcdManagedZone -Project $nonExistProject } | Should Throw "403"
     }
 
     It "should give access errors as appropriate" {
@@ -62,7 +62,7 @@ Describe "Add-GcdManagedZone" {
     }
 
     It "should fail to create a ManagedZone in a non-existent project" {
-        { Add-GcdManagedZone -Project $nonExistProject $testZone1 $dnsName1 } | Should Throw "404"
+        { Add-GcdManagedZone -Project $nonExistProject $testZone1 $dnsName1 } | Should Throw "403"
     }
 
     It "should give access errors as appropriate" {
@@ -114,7 +114,7 @@ Describe "Remove-GcdManagedZone" {
     }
 
     It "should fail to delete a ManagedZone in a non-existent project" {
-        { Remove-GcdManagedZone -Project $nonExistProject $testZone1 } | Should Throw "404"
+        { Remove-GcdManagedZone -Project $nonExistProject $testZone1 } | Should Throw "403"
     }
 
     It "should give access errors as appropriate" {

--- a/Google.PowerShell.IntegrationTests/Dns/Dns.GcdQuota.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Dns/Dns.GcdQuota.Tests.ps1
@@ -5,7 +5,7 @@ $project, $zone, $oldActiveConfig, $configName = Set-GCloudConfig
 Describe "Get-GcdQuota" {
 
     It "should fail to return DNS quota of non-existent project" {
-        { Get-GcdQuota -Project $nonExistProject } | Should Throw "404"
+        { Get-GcdQuota -Project $nonExistProject } | Should Throw "403"
     }
 
     It "should give access errors as appropriate" {

--- a/Google.PowerShell.IntegrationTests/Dns/Dns.GcdResourceRecordSet.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Dns/Dns.GcdResourceRecordSet.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Get-GcdResourceRecordSet" {
     }
 
     It "should fail to return ResourceRecordSets of non-existent project" {
-        { Get-GcdResourceRecordSet -Project $nonExistProject $testZone1 } | Should Throw "404"
+        { Get-GcdResourceRecordSet -Project $nonExistProject $testZone1 } | Should Throw "403"
     }
 
     It "should give access errors as appropriate" {

--- a/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
+++ b/Google.PowerShell.IntegrationTests/Storage/Storage.GcsObject.Tests.ps1
@@ -1247,9 +1247,9 @@ Describe "Write-GcsObject" {
         $newObjectCase.ContentLanguage | Should Be "en"
 
         $both = "XXX" | Write-GcsObject $bucket "content-type-test" `
-            -Metadata @{ "Content-Type" = "test/beta"; "Content-Language" = "bb" }
+            -Metadata @{ "Content-Type" = "test/beta"; "Content-Language" = "aa" }
         $both.ContentType | Should Be "test/beta"
-        $both.ContentLanguage | Should Be "bb"
+        $both.ContentLanguage | Should Be "aa"
 
         Remove-GcsObject $bucket "content-type-test"
     }

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -81,6 +81,11 @@ namespace Google.PowerShell.CloudStorage
         /// </summary>
         public static string InferContentType(string file)
         {
+            if (file == null)
+            {
+                return OctetStreamMimeType;
+            }
+
             int index = file.LastIndexOf('.');
             if (index == -1)
             {

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -76,7 +76,8 @@ namespace Google.PowerShell.CloudStorage
         }
 
         /// <summary>
-        /// Infer the MIME type of a non-qualified file path. Returns null if no match is found.
+        /// Infer the MIME type of a non-qualified file path.
+        /// Returns octet stream mime type if no match is found.
         /// </summary>
         public static string InferContentType(string file)
         {
@@ -110,37 +111,6 @@ namespace Google.PowerShell.CloudStorage
         }
 
         /// <summary>
-        /// Return the content type to use for a Cloud Storage object given existing values, defauts, etc. The order of
-        /// precidence is:
-        /// 1. New content type, e.g. a ContentType parameter.
-        /// 2. New metadata, e.g. Metadata value specified via parameter.
-        /// 3. Default content type to apply (potentially null), e.g. sniffing file content.
-        /// If no match is found, will return OctetStreamMimeType.
-        /// </summary>
-        public string GetContentType(
-            string newContentType,
-            Dictionary<string, string> newMetadata,
-            string defaultContentType = null)
-        {
-            if (!String.IsNullOrEmpty(newContentType))
-            {
-                return newContentType;
-            }
-
-            if (newMetadata != null && newMetadata.ContainsKey("Content-Type"))
-            {
-                return newMetadata["Content-Type"];
-            }
-
-            if (!String.IsNullOrEmpty(defaultContentType))
-            {
-                return defaultContentType;
-            }
-
-            return OctetStreamMimeType;
-        }
-
-        /// <summary>
         /// Gets fixed type metadata from the cmdlet parameter if user provides that.
         /// If not, tries retrieving it from the metadata dictionary using keyNameInMetadataDictionary.
         /// If that also fails, returns the default content type.
@@ -148,9 +118,9 @@ namespace Google.PowerShell.CloudStorage
         /// <returns></returns>
         protected string GetFixedTypeMetadata(
             string parameterName,
-            Dictionary<string, string> metadataDictionary,
+            IReadOnlyDictionary<string, string> metadataDictionary,
             string keyNameInMetadataDictionary,
-            string defaultContentType = null)
+            string defaultValue = null)
         {
             if (MyInvocation.BoundParameters.ContainsKey(parameterName))
             {
@@ -162,7 +132,7 @@ namespace Google.PowerShell.CloudStorage
                 return metadataDictionary[keyNameInMetadataDictionary];
             }
 
-            return defaultContentType;
+            return defaultValue;
         }
     }
 }

--- a/Google.PowerShell/Storage/GcsCmdlet.cs
+++ b/Google.PowerShell/Storage/GcsCmdlet.cs
@@ -139,5 +139,30 @@ namespace Google.PowerShell.CloudStorage
 
             return OctetStreamMimeType;
         }
+
+        /// <summary>
+        /// Gets fixed type metadata from the cmdlet parameter if user provides that.
+        /// If not, tries retrieving it from the metadata dictionary using keyNameInMetadataDictionary.
+        /// If that also fails, returns the default content type.
+        /// </summary>
+        /// <returns></returns>
+        protected string GetFixedTypeMetadata(
+            string parameterName,
+            Dictionary<string, string> metadataDictionary,
+            string keyNameInMetadataDictionary,
+            string defaultContentType = null)
+        {
+            if (MyInvocation.BoundParameters.ContainsKey(parameterName))
+            {
+                return MyInvocation.BoundParameters[parameterName] as string;
+            }
+
+            if (metadataDictionary != null && metadataDictionary.ContainsKey(keyNameInMetadataDictionary))
+            {
+                return metadataDictionary[keyNameInMetadataDictionary];
+            }
+
+            return defaultContentType;
+        }
     }
 }

--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -508,16 +508,16 @@ namespace Google.PowerShell.CloudStorage
             UploadStreamToGcsObject(contentStream, objContentType, metadataDict, gcsObjectNamePrefix);
 
             // TODO(quoct): Add a progress indicator if there are too many files.
-            foreach (string file in Directory.EnumerateFiles(directory))
+            foreach (string enumeratedFile in Directory.EnumerateFiles(directory))
             {
-                string fileName = Path.GetFileName(file);
+                string fileName = Path.GetFileName(enumeratedFile);
                 string fileWithGcsObjectNamePrefix = Path.Combine(gcsObjectNamePrefix, fileName);
                 // We have to replace \ with / so it will be created with correct folder structure.
                 fileWithGcsObjectNamePrefix = ConvertLocalToGcsFolderPath(fileWithGcsObjectNamePrefix);
                 UploadStreamToGcsObject(
-                    new FileStream(file, FileMode.Open),
+                    new FileStream(enumeratedFile, FileMode.Open),
                     GetFixedTypeMetadata(
-                        nameof(ContentType), metadataDict, ContentTypeKeyMetadata, InferContentType(File)),
+                        nameof(ContentType), metadataDict, ContentTypeKeyMetadata, InferContentType(enumeratedFile)),
                     metadataDict,
                     ConvertLocalToGcsFolderPath(fileWithGcsObjectNamePrefix));
             }
@@ -558,13 +558,13 @@ namespace Google.PowerShell.CloudStorage
                 }
 
                 string cacheControl =
-                    GetFixedTypeMetadata(nameof(CacheControl), metadataDict, "Cache-Control");
+                    GetFixedTypeMetadata(nameof(CacheControl), metadataDict, CacheControlKeyMetadata);
                 string contentDisposition =
-                    GetFixedTypeMetadata(nameof(ContentDisposition), metadataDict, "Content-Disposition");
+                    GetFixedTypeMetadata(nameof(ContentDisposition), metadataDict, ContentDispositionKeyMetadata);
                 string contentEncoding =
-                    GetFixedTypeMetadata(nameof(ContentEncoding), metadataDict, "Content-Encoding");
+                    GetFixedTypeMetadata(nameof(ContentEncoding), metadataDict, ContentEncodingKeyMetadata);
                 string contentLanguage =
-                    GetFixedTypeMetadata(nameof(ContentLanguage), metadataDict, "Content-Language");
+                    GetFixedTypeMetadata(nameof(ContentLanguage), metadataDict, ContentLanguageKeyMetadata);
 
                 Object newGcsObject = UploadGcsObject(
                     Service, Bucket, objectName, contentStream,


### PR DESCRIPTION
This should fix https://github.com/GoogleCloudPlatform/google-cloud-powershell/issues/626. See [link](https://cloud.google.com/storage/docs/metadata#mutable) for more information on fixed-key metadata.

Also fixes minor test errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-powershell/627)
<!-- Reviewable:end -->
