### PR TITLE
Add remaining allowed DiskTypes for -DiskType parameter validateset

### DIFF
--- a/Google.PowerShell/Compute/GceDisk.cs
+++ b/Google.PowerShell/Compute/GceDisk.cs
@@ -218,7 +218,7 @@ namespace Google.PowerShell.ComputeEngine
         /// Type of disk, e.g. pd-ssd or pd-standard.
         /// </para>
         /// </summary>
-        [Parameter, ValidateSet("pd-ssd", "pd-standard")]
+        [Parameter, ValidateSet("pd-ssd", "pd-standard", "pd-balanced", "pd-extreme")]
         public string DiskType { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Fixes #651

Added allowed `pd-balanced` and `pd-extreme` disktypes to allowed values of `-DiskType` parameter.