### PR TITLE
remove slash symbol in "prefix" params

### DIFF
--- a/Google.PowerShell/Storage/GcsObject.cs
+++ b/Google.PowerShell/Storage/GcsObject.cs
@@ -668,7 +668,7 @@ namespace Google.PowerShell.CloudStorage
 
         /// <summary>
         /// <para type="description">
-        /// Object prefix to use. e.g. "/logs/". If not specified all
+        /// Object prefix to use. e.g. "logs/". If not specified all
         /// objects in the bucket will be returned.
         /// </para>
         /// </summary>


### PR DESCRIPTION
This pull request includes a minor documentation update to the `GetGcsObjectCmdlet` class in the `Google.PowerShell/Storage/GcsObject.cs` file. The change corrects the example prefix in the description from `"/logs/"` to `"logs/"` for clarity and consistency.